### PR TITLE
Speed up CI when SKIP_AUTH_TESTS is enabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,14 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps
+        run: |
+          if [ "${SKIP_AUTH_TESTS}" = "true" ] || [ "${SKIP_AUTH_TESTS}" = "1" ]; then
+            echo "SKIP_AUTH_TESTS is set - installing chromium only"
+            npx playwright install --with-deps chromium
+          else
+            echo "Installing all browsers"
+            npx playwright install --with-deps
+          fi
 
       - name: Run E2E tests
         run: npm run test:e2e

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,13 @@ const authStatePath = path.join(__dirname, 'e2e', '.auth', 'user.json')
 const hasAuthState = fs.existsSync(authStatePath)
 
 /**
+ * When auth tests are skipped, we can run Chromium-only to speed up CI.
+ * (Most suites are either skipped or primarily validated in one engine.)
+ */
+const skipAuthTests =
+  process.env.SKIP_AUTH_TESTS === 'true' || process.env.SKIP_AUTH_TESTS === '1'
+
+/**
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
@@ -47,28 +54,32 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { 
+      use: {
         ...devices['Desktop Chrome'],
         /* Load auth state if it exists (created by global setup) */
         ...(hasAuthState && { storageState: authStatePath }),
       },
     },
 
-    {
-      name: 'firefox',
-      use: { 
-        ...devices['Desktop Firefox'],
-        ...(hasAuthState && { storageState: authStatePath }),
-      },
-    },
+    ...(skipAuthTests
+      ? []
+      : [
+          {
+            name: 'firefox',
+            use: {
+              ...devices['Desktop Firefox'],
+              ...(hasAuthState && { storageState: authStatePath }),
+            },
+          },
 
-    {
-      name: 'webkit',
-      use: { 
-        ...devices['Desktop Safari'],
-        ...(hasAuthState && { storageState: authStatePath }),
-      },
-    },
+          {
+            name: 'webkit',
+            use: {
+              ...devices['Desktop Safari'],
+              ...(hasAuthState && { storageState: authStatePath }),
+            },
+          },
+        ]),
 
     /* Test against mobile viewports. */
     // {


### PR DESCRIPTION
## Summary
- Run Playwright **Chromium-only** when `SKIP_AUTH_TESTS=true|1` to avoid spending time on Firefox/WebKit when auth suites are intentionally skipped.
- In CI, install **only Chromium** in skip-auth mode instead of `--with-deps` for all browsers.
- Keeps full cross-browser coverage when `SKIP_AUTH_TESTS` is not enabled.

## Test plan
- [ ] Verify GitHub Actions `E2E Tests` runtime drops significantly on this PR.
- [ ] Confirm E2E still runs all browsers when `SKIP_AUTH_TESTS` is unset/false.