### PR TITLE
Fix #42: group-user assignment

### DIFF
--- a/src/app/dashboard/clients/[id]/__tests__/group-user-assignment.test.tsx
+++ b/src/app/dashboard/clients/[id]/__tests__/group-user-assignment.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import ClientGroups from '../client-groups'
+import { useRouter } from 'next/navigation'
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}))
+
+const mockSupabase = {
+  from: vi.fn(),
+  auth: {
+    getUser: vi.fn(),
+  },
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase,
+}))
+
+describe('Group-user assignment (ClientGroups)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(useRouter).mockReturnValue({ refresh: vi.fn() } as any)
+
+    // ClientGroups uses confirm/alert in some flows
+    global.confirm = vi.fn()
+    global.alert = vi.fn()
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'profiles') {
+        return {
+          select: vi.fn().mockReturnValue({
+            // loadUsers()
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+            // loadGroups() target lookup
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }
+      }
+
+      if (table === 'groups') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: 'group-1',
+                    client_id: 'client-1',
+                    name: 'Engineering',
+                    description: null,
+                    target_id: null,
+                    created_at: '2024-01-01T00:00:00Z',
+                    updated_at: '2024-01-01T00:00:00Z',
+                    group_members: [
+                      {
+                        id: 'gm-1',
+                        profile_id: 'user-1',
+                        role: 'Developer',
+                        profiles: {
+                          id: 'user-1',
+                          name: 'Jane Smith',
+                          email: 'jane@example.com',
+                          username: 'janesmith',
+                        },
+                      },
+                    ],
+                  },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      return {
+        select: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }
+    })
+  })
+
+  it('renders group members with role from group_members.role', async () => {
+    render(<ClientGroups clientId="client-1" />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Engineering')).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument()
+    expect(screen.getByText('(Developer)')).toBeInTheDocument()
+  })
+})

--- a/src/app/dashboard/clients/[id]/client-groups.tsx
+++ b/src/app/dashboard/clients/[id]/client-groups.tsx
@@ -16,8 +16,7 @@ type GroupUpdate = Database['public']['Tables']['groups']['Update']
 interface GroupMember {
   id?: string
   profile_id: string
-  position: string
-  leader: boolean
+  role: string
   profile?: {
     id: string
     name: string
@@ -93,8 +92,7 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
         group_members(
           id,
           profile_id,
-          position,
-          leader,
+          role,
           profiles(id, name, email, username)
         )
       `)
@@ -127,8 +125,7 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
         members: group.group_members?.map((gm: GroupMemberRow & { profiles?: Profile }) => ({
           id: gm.id,
           profile_id: gm.profile_id,
-          position: gm.role || '',
-          leader: false, // This field doesn't exist in the database schema
+          role: gm.role || '',
           profile: gm.profiles
         })) || []
       }))
@@ -177,8 +174,7 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
         const membersToInsert = groupMembers.map(member => ({
           group_id: newGroup.id,
           profile_id: member.profile_id,
-          position: member.position || '',
-          leader: member.leader || false,
+          role: member.role || '',
         }))
 
         const { error: membersError } = await supabase
@@ -253,8 +249,7 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
         const membersToInsert = groupMembers.map(member => ({
           group_id: editingGroup.id,
           profile_id: member.profile_id,
-          position: member.position || '',
-          leader: member.leader || false,
+          role: member.role || '',
         }))
 
         const { error: membersError } = await supabase
@@ -330,8 +325,7 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
       .filter(user => !groupMembers.some(m => m.profile_id === user.id))
       .map(user => ({
         profile_id: user.id,
-        position: '',
-        leader: false,
+        role: '',
         profile: user
       }))
 
@@ -344,15 +338,9 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
     setGroupMembers(groupMembers.filter((_, i) => i !== index))
   }
 
-  const handleUpdateMemberPosition = (index: number, position: string) => {
+  const handleUpdateMemberRole = (index: number, role: string) => {
     const updated = [...groupMembers]
-    updated[index].position = position
-    setGroupMembers(updated)
-  }
-
-  const handleUpdateMemberLeader = (index: number, leader: boolean) => {
-    const updated = [...groupMembers]
-    updated[index].leader = leader
+    updated[index].role = role
     setGroupMembers(updated)
   }
 
@@ -491,8 +479,7 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
         const membersToInsert = groupData.users.map(user => ({
           group_id: newGroup.id,
           profile_id: user.id,
-          position: user.role || '',
-          leader: false,
+          role: user.role || '',
         }))
 
         const { error: membersError } = await supabase
@@ -650,7 +637,7 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
                       >
                         ✕
                       </button>
-                      <div className="grid grid-cols-3 gap-4">
+                      <div className="grid grid-cols-2 gap-4">
                         <div>
                           <h5 className="font-medium text-gray-900">{user.name}</h5>
                           <p className="text-xs text-gray-500">User ID: {user.username || user.id}</p>
@@ -658,28 +645,15 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
                         </div>
                         <div>
                           <label className="block text-xs font-medium text-gray-700 mb-1">
-                            Position In Group
+                            Role In Group
                           </label>
                           <input
                             type="text"
-                            value={member.position}
-                            onChange={(e) => handleUpdateMemberPosition(index, e.target.value)}
+                            value={member.role}
+                            onChange={(e) => handleUpdateMemberRole(index, e.target.value)}
                             className="w-full px-2 py-1 text-sm border border-gray-300 rounded"
                             placeholder="e.g., Developer, Manager"
                           />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-medium text-gray-700 mb-1">
-                            Leadership Position?
-                          </label>
-                          <select
-                            value={member.leader ? '1' : '0'}
-                            onChange={(e) => handleUpdateMemberLeader(index, e.target.value === '1')}
-                            className="w-full px-2 py-1 text-sm border border-gray-300 rounded"
-                          >
-                            <option value="0">No</option>
-                            <option value="1">Yes</option>
-                          </select>
                         </div>
                       </div>
                     </div>
@@ -845,9 +819,9 @@ export default function ClientGroups({ clientId }: ClientGroupsProps) {
                               return (
                                 <div key={member.id || member.profile_id}>
                                   {user.name}
-                                  {member.position && (
-                                    <span className={member.position.toLowerCase() === 'self' ? 'text-green-600' : ''}>
-                                      {' '}({member.position})
+                                  {member.role && (
+                                    <span className={member.role.toLowerCase() === 'self' ? 'text-green-600' : ''}>
+                                      {' '}({member.role})
                                     </span>
                                   )}
                                 </div>


### PR DESCRIPTION
## Summary
- Fix group membership assignment in the Client Groups UI by aligning with the `group_members` table schema.
- Use `group_members.role` (and remove references to non-existent `position`/`leader` fields).

## Test plan
- [x] `npm test`