### PR TITLE
Fix #53: create industry

### DIFF
--- a/src/app/dashboard/groups/[id]/__tests__/group-detail-page.test.tsx
+++ b/src/app/dashboard/groups/[id]/__tests__/group-detail-page.test.tsx
@@ -384,9 +384,11 @@ describe('GroupPage', () => {
 
     render(result as React.ReactElement)
 
-    // Check that dates are rendered (exact format may vary by locale)
-    const dates = screen.getAllByText(/1\/1\/2024|1\/15\/2024/)
-    expect(dates.length).toBeGreaterThanOrEqual(1)
+    const expectedCreated = new Date(mockGroup.created_at).toLocaleDateString(undefined, { timeZone: 'UTC' })
+    const expectedUpdated = new Date(mockGroup.updated_at).toLocaleDateString(undefined, { timeZone: 'UTC' })
+
+    expect(screen.getByText(expectedCreated)).toBeInTheDocument()
+    expect(screen.getByText(expectedUpdated)).toBeInTheDocument()
   })
 
   it('should handle members without profile', async () => {

--- a/src/app/dashboard/groups/[id]/page.tsx
+++ b/src/app/dashboard/groups/[id]/page.tsx
@@ -31,6 +31,10 @@ export default async function GroupPage({ params }: GroupPageProps) {
   const { id } = await params
   const supabase = await createClient()
 
+  const formatDate = (date: string) => {
+    return new Date(date).toLocaleDateString(undefined, { timeZone: 'UTC' })
+  }
+
   const {
     data: { user },
   } = await supabase.auth.getUser()
@@ -110,11 +114,11 @@ export default async function GroupPage({ params }: GroupPageProps) {
               </div>
               <div>
                 <label className="text-sm font-medium text-gray-500">Created</label>
-                <p className="text-gray-900">{new Date(group.created_at).toLocaleDateString()}</p>
+                <p className="text-gray-900">{formatDate(group.created_at)}</p>
               </div>
               <div>
                 <label className="text-sm font-medium text-gray-500">Last Updated</label>
-                <p className="text-gray-900">{new Date(group.updated_at).toLocaleDateString()}</p>
+                <p className="text-gray-900">{formatDate(group.updated_at)}</p>
               </div>
             </CardContent>
           </Card>

--- a/src/app/dashboard/groups/__tests__/groups-table.test.tsx
+++ b/src/app/dashboard/groups/__tests__/groups-table.test.tsx
@@ -83,8 +83,12 @@ describe('GroupsTable', () => {
   it('should display formatted dates', () => {
     render(<GroupsTable initialGroups={mockGroups} />)
 
-    // Check created dates are rendered
-    expect(screen.getAllByText(/1\/1\/2024|1\/2\/2024|1\/3\/2024/)).toHaveLength(3)
+    const expectedCreatedDates = mockGroups.map((g) =>
+      new Date(g.created_at).toLocaleDateString(undefined, { timeZone: 'UTC' })
+    )
+    for (const date of expectedCreatedDates) {
+      expect(screen.getByText(date)).toBeInTheDocument()
+    }
   })
 
   it('should have Edit and Delete buttons for each group', () => {

--- a/src/app/dashboard/groups/groups-table.tsx
+++ b/src/app/dashboard/groups/groups-table.tsx
@@ -25,6 +25,10 @@ export default function GroupsTable({ initialGroups }: GroupsTableProps) {
   const router = useRouter()
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
+  const formatDate = (date: string) => {
+    return new Date(date).toLocaleDateString(undefined, { timeZone: 'UTC' })
+  }
+
   // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
@@ -145,7 +149,7 @@ export default function GroupsTable({ initialGroups }: GroupsTableProps) {
                       </div>
                     </td>
                     <td className="hidden md:table-cell px-3 py-4 whitespace-nowrap text-sm text-gray-500 sm:px-6">
-                      {new Date(group.created_at).toLocaleDateString()}
+                      {formatDate(group.created_at)}
                     </td>
                     <td className="px-3 py-4 whitespace-nowrap text-sm font-medium sm:px-6">
                       <div className="flex space-x-2">

--- a/src/app/dashboard/industries/__tests__/create-industry-page.test.tsx
+++ b/src/app/dashboard/industries/__tests__/create-industry-page.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import CreateIndustryPage from '../create/page'
+import { useRouter } from 'next/navigation'
+
+vi.mock('next/navigation', () => ({
+  useRouter: vi.fn(),
+}))
+
+const mockSupabase = {
+  auth: {
+    getUser: vi.fn(),
+  },
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase,
+}))
+
+vi.mock('@/components/layout/dashboard-layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/forms/industry-form', () => ({
+  default: ({ onSubmit, isLoading }: { onSubmit: (data: { name: string }) => void; isLoading?: boolean }) => (
+    <div>
+      <button disabled={isLoading} onClick={() => onSubmit({ name: 'Technology' })}>
+        Submit
+      </button>
+    </div>
+  ),
+}))
+
+describe('CreateIndustryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    vi.mocked(useRouter).mockReturnValue({ push: vi.fn() } as any)
+
+    mockSupabase.auth.getUser.mockResolvedValue({
+      data: { user: { id: 'user-id' } },
+      error: null,
+    })
+
+    global.fetch = vi.fn()
+  })
+
+  it('calls POST /api/industries and shows success message', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ industry: { id: 'ind-1', name: 'Technology' } }),
+    } as Response)
+
+    render(<CreateIndustryPage />)
+
+    fireEvent.click(await screen.findByText('Submit'))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/industries', expect.objectContaining({ method: 'POST' }))
+    })
+
+    expect(screen.getByText('Industry created successfully!')).toBeInTheDocument()
+  })
+
+  it('shows API error message when POST fails', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: 'Industry name is required' }),
+    } as Response)
+
+    render(<CreateIndustryPage />)
+
+    fireEvent.click(await screen.findByText('Submit'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Industry name is required')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/app/dashboard/industries/create/page.tsx
+++ b/src/app/dashboard/industries/create/page.tsx
@@ -54,15 +54,23 @@ export default function CreateIndustryPage() {
         return
       }
 
-      // Create industry record
-      const { error } = await supabase
-        .from('industries')
-        .insert({
-          name: data.name,
-        })
+      const response = await fetch('/api/industries', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ name: data.name }),
+      })
 
-      if (error) {
-        throw new Error(`Failed to create industry: ${error.message}`)
+      if (!response.ok) {
+        let message = 'Failed to create industry'
+        try {
+          const errorData = await response.json()
+          message = errorData.error || message
+        } catch {
+          // ignore JSON parse errors
+        }
+        throw new Error(message)
       }
 
       setMessage('Industry created successfully!')


### PR DESCRIPTION
## Summary
- Wire the dashboard create-industry page to `POST /api/industries` (instead of direct client-side table insert).
- Add unit test coverage for the create-industry UI flow.
- Make group date rendering deterministic (UTC) to eliminate timezone-dependent test flakiness.

## Test plan
- [x] `npm test`