### PR TITLE
Fix #63: delete benchmark

### DIFF
--- a/src/app/dashboard/benchmarks/[assessmentId]/[industryId]/__tests__/benchmarks-manage-client.test.tsx
+++ b/src/app/dashboard/benchmarks/[assessmentId]/[industryId]/__tests__/benchmarks-manage-client.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import BenchmarksManageClient from '../benchmarks-manage-client'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => <a href={href}>{children}</a>,
+}))
+
+vi.mock('@/components/layout/dashboard-layout', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/card', () => ({
+  Card: ({ children }: any) => <div>{children}</div>,
+  CardContent: ({ children }: any) => <div>{children}</div>,
+  CardHeader: ({ children }: any) => <div>{children}</div>,
+  CardTitle: ({ children }: any) => <h3>{children}</h3>,
+  CardDescription: ({ children }: any) => <div>{children}</div>,
+}))
+
+const mockSupabase = {
+  from: vi.fn(),
+}
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => mockSupabase,
+}))
+
+describe('BenchmarksManageClient delete benchmark', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.fetch = vi.fn()
+    global.confirm = vi.fn()
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'assessments') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'assessment-1', title: 'Assessment 1' },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'industries') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({
+                data: { id: 'industry-1', name: 'Technology' },
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'dimensions') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              order: vi.fn().mockResolvedValue({
+                data: [
+                  { id: 'dim-1', name: 'Communication', code: 'COMM', assessment_id: 'assessment-1' },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+        }
+      }
+
+      if (table === 'benchmarks') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockResolvedValue({
+                data: [
+                  { id: 'bm-1', dimension_id: 'dim-1', industry_id: 'industry-1', value: 75.5 },
+                ],
+                error: null,
+              }),
+            }),
+          }),
+          upsert: vi.fn().mockResolvedValue({ error: null }),
+          delete: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }
+      }
+
+      return {
+        select: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }
+    })
+  })
+
+  it('calls DELETE /api/benchmarks/:id when deleting a saved benchmark', async () => {
+    vi.mocked(confirm).mockReturnValue(true)
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ message: 'Benchmark deleted successfully' }),
+    } as Response)
+
+    render(<BenchmarksManageClient assessmentId="assessment-1" industryId="industry-1" />)
+
+    // Wait for row to render
+    await waitFor(() => {
+      expect(screen.getByText('Communication')).toBeInTheDocument()
+    })
+
+    // Ensure value is present
+    const valueInput = screen.getByDisplayValue('75.5')
+    expect(valueInput).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/benchmarks/bm-1', { method: 'DELETE' })
+    })
+
+    // Value should be cleared
+    await waitFor(() => {
+      const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+      expect(input.value).toBe('')
+    })
+
+    expect(screen.getByText('Benchmark deleted successfully!')).toBeInTheDocument()
+  })
+})

--- a/src/app/dashboard/benchmarks/__tests__/benchmarks-list-table.test.tsx
+++ b/src/app/dashboard/benchmarks/__tests__/benchmarks-list-table.test.tsx
@@ -105,8 +105,12 @@ describe('BenchmarksListTable', () => {
   it('should display formatted dates', () => {
     render(<BenchmarksListTable initialBenchmarks={mockBenchmarks} />)
 
-    // Check updated dates are rendered
-    expect(screen.getAllByText(/1\/1\/2024|1\/2\/2024|1\/3\/2024/)).toHaveLength(3)
+    const expectedUpdatedDates = mockBenchmarks.map((b) =>
+      new Date(b.updated_at).toLocaleDateString(undefined, { timeZone: 'UTC' })
+    )
+    for (const date of expectedUpdatedDates) {
+      expect(screen.getByText(date)).toBeInTheDocument()
+    }
   })
 
   it('should have Edit and Delete buttons for each benchmark', () => {

--- a/src/app/dashboard/benchmarks/benchmarks-list-table.tsx
+++ b/src/app/dashboard/benchmarks/benchmarks-list-table.tsx
@@ -26,6 +26,10 @@ export default function BenchmarksListTable({ initialBenchmarks }: BenchmarksLis
   const router = useRouter()
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
 
+  const formatDate = (date: string) => {
+    return new Date(date).toLocaleDateString(undefined, { timeZone: 'UTC' })
+  }
+
   // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
@@ -135,7 +139,7 @@ export default function BenchmarksListTable({ initialBenchmarks }: BenchmarksLis
                       </span>
                     </td>
                     <td className="hidden md:table-cell px-3 py-4 whitespace-nowrap text-sm text-gray-500 sm:px-6">
-                      {benchmark.updated_at ? new Date(benchmark.updated_at).toLocaleDateString() : '—'}
+                      {benchmark.updated_at ? formatDate(benchmark.updated_at) : '—'}
                     </td>
                     <td className="px-3 py-4 whitespace-nowrap text-sm font-medium sm:px-6">
                       <div className="flex space-x-2">


### PR DESCRIPTION
## Summary
- Add a per-dimension delete action in the benchmark manager (`/dashboard/benchmarks/[assessmentId]/[industryId]`) that calls `DELETE /api/benchmarks/:id`.
- Add unit test coverage for deleting an existing benchmark.
- Make benchmark list date rendering deterministic (UTC) to prevent timezone-dependent unit test failures.

## Test plan
- [x] `npm test`