### PR TITLE
Add surveys table, fix report collisions and display bugs

### DIFF
--- a/history/involved.md
+++ b/history/involved.md
@@ -1,143 +1,26 @@
-# Log of Initiatives for Involved V2
+The definitions of the dimensions now show on the assessment page - like a list of them, then the first questions. They appear on the first dimension page, not the others. The page is right after the instructions. This is for the Involve-360 Frontier. The rest of the workflow seems to work nicely. Once this is fixed, I will have everybody take the 360 so we can test reporting, data integraity, pdfs, etc.
 
-you were using:
-admin@demo.com
-Test123$
+we need to review the example in the production environment where he's testing and consider that we may have done something weird during the data migration. confirm first whether this is a new record or whether it builds on existing records that we migrated over. 
 
-so it sounds like the reason the client didn't see any changes was because there were undeployed changes. and a reason why he might still not see some of them is because the report was generated before the changes were made and is cached in a way and will need to be rerun to pick up the changes. also, he might still not notice the dimention definitions becuase they may actually not be defined. but other than that he should see many updates.
+actually, lets do this differently. lets export the frontier 360 assessment including fields, dimensions, etc and we'll add it to a seeder so that we can still run reset and then use the seeder and survey simulator to test a comparable campaign.
 
-do you have the context of what all the client last reported when we started this branch? we had a client pipeline in gusclaw that had mixed results but it did manage to create many issues even if the prs didn't quite address everything without a human touch given the nature of the changes (style, layout, etc.). check the gus memory and the recent issues and the client pipeline for insight into what all was requested in terms of bug fixes and revisions. we want to try and compare this to the commit history and the current state of the code and address anything we missed.
+we also need to discuss how we're going to smoke test and load test this for the first client. we need to prepare a test plan based on what we expect the initial user base to be and map out some scenarios that might be found in the wild. i want to pay particularly close attention to things like emails, notificaitons, login flows, pdf generation, data exports, score validation. i want to map out end to end scenarios for surveys and then run different variants to try and find edge cases. we need to make sure we're covering all of the bases and that we're not missing anything. we're in a unique position in that our first client is a fairly definable set of cases that will be controlled for a period of time. we should be able to exhaustively plan for frontier airlines. in the future this will be more organic and unpredictable as we scale. but if we can nail frontier, it will unlock more possibilities to expand. 
 
-on the front page of the reports, the involved logo is too high. our latest example is https://involved-v2.cyberworldbuilders.dev/reports/3eda9e70-c171-475b-820e-295910470e0b/view. we've gotten it a lot lower but it looks like he wants it all the way down to the bottom of the page.
+we also want to improve upon our email tracking interface. lets review what we've built and consider what is possible with ses. we need to be able to track the assignment and notification emails for each participant in each survey. we're going to need to be able to support users if anything goes wrong. so i need to be able to quickly respond to any issues that arise. it's very important that we have a solid system in place so that we can confidently enter into tech support issues assuming user error as opposed to assuming that a bug needs to be patched. many of these presumed bugs will be related to emails. keep in mind that most of the users are going to be employees that could care less if they participate in these surveys. some of them will even be combative. if they can find a bug or make us think that we have a bug, they can get us on our back foot and create doubt in management in our ability to deliver on this project. most users will not be excited to use our product by its very nature. we should anticipate a lot of foot dragging and sand bagging. any user that is tech savy in any way and resentful will actively try to break and potentially exploit bugs. so we need a clear and dependable trail of activity so that we can present clear evidence of abuse. some examples are:
+- "i never got the email." we need to be able to pull up ses logs and show where the email went out. or if we can show somewhere that they entered their email in incorrectly or at least say with confidence that the assignment was not sent. it could be user error on the part of the admin. we need to be able to show in the audit trail that it was not a bug. that x person who is an admin creating the survey entered y assignment in wrong. consider that some of the accusation of bugs may come from our own team. i need to be able to quickly diagnose exactly what happened. did the participant get selected in the survey? was the notification/reminder box checked at assignment time? was it updated later? did the email get queued? did it get triggered in ses? did ses attempt to send the email? we need to be able to pull this entire trail end to end quickly so that we do not get pressure to troubleshoot the codebase and deploy patches franticly. there's probably a potential for the queue to get overloaded so we need to make sure and reduce the possibiliy of congestion as much as possible.
+- "i can't log in". we need a trail of what all they clicked on. this could be access logs, audit logs, etc. we need to be able to trace what all they are trying to do quickly before they even set up a support session. we have gone to great lengths to simplify the login process. they should be able to log in from a magic link straight from the login screen. we need to be able to know if maybe they entered in the wrong email address in the login link request. we might even want to make the link to the assessment act as a magic login link (that's probably not possible since magic links need an expiration. we probably just have to tolerate one step of extra friction). at the very least we need a trail of activity in case they're doing something obviously stupid.
+- "i can't find my assessment". maybe we should add some tooltips to help them navigate their dashboard. after they log in for the first time, linking out to assessments should be smooth. the flow is designed to take them straight to the assessment in the email. however, sometimes the assessments will pile up. i think we have it where the user gets one email with all assessments. we may have removed that altogether in favor of the dashboard to avoid confusion. it could be a hybrid, though. they could be sending multiple links for a single assessment if they are assigned to multiple surveys simultaneously in order to reduce spam but there is a scenario where they get added to or removed from surveys later. this is why the dashboard is so important. (lets investigate and discuss). but the fallback is the dashboard where all assessments are listed. we need this to be intuitive with helpful tooltips or messages that guide them along. 
 
-page two has some text that mentions "norms". this should be changed to "geonorms".
+----
 
-ok i see what's happening. on the titles that are long enough to wrap, it goes full width. i don't have an example in the "clean" report that wraps so it's unclear what to do in this scenario. maybe we should actually make the title smaller to try and avoid wrapping. 
+analyze this video from yesterday. generate a transcript for reference. ask me any clarifying questions. the examples are all in the production environment at my.involvedtalent.com. the staging environment seems to be working fine. it seems like a lot of this is related to a recent data migration where we moved several survey/assessment records with complex relations to other tables. so review the history of the migration for additional context. there apears to be about 5 points to address:
+1. Survey collisions. The data from two separate surveys appears to be combining in the scores. There is an example in the video. 
+2. Geonorm/score cards switched. For some reason these cards are swapped. This should be a simple fix. May want to check other reports and see if this is consistent across all of them. 
+3. PDF generation is broken. This appears to be consistent across all reports. The fix should fix all of them.
+4. Benchmarks are empty on reports. The benchmarks are set but they are not appearing in the reports. This is probably related to the migration but don't take my word for it. Let's investigate and fix.
+5. Email reminders. We're not seeing any logs for a recent email reminder that was supposed to be sent out. First we need to verify that the reminder box was checked and that the reminder date and frequency were set correctly. Look for any records at all. There should be less than 5 and maybe as few as 2 events where reminders were tested, although at least one of these was a whole group. so we should see logs in our email tracker that combines aws ses log ingestion with our own internal logging. i know i worked on this recently. he can't remember for sure if he checked the box and i don't recall if i tested on prod or just staging. and i can't remember when i fixed what i fixed so it could have been fixed after he tested his. or i could have started the test and walked away and forgot about it and it actually never got fixed. 
+6. Industry not showing correctly. In the example instead of the actual industry it says "Industry". Please investigate. 
 
-Replacing the single-rater image with the marked-up version and updating the README: removing it from "preferred" references and documenting it as a problem example.
+but do a deep analysis of the video before you start anything.  just keep this in mind as a studyguide so to speak.
 
-Updating the README: the single-rater asset is a problem example with markup; only the five-rater image remains the preferred reference.
-
-README.md
-+22
--7
-| [`client-feedback-creative-problem-solving.png`](./client-feedback-creative-problem-solving.png) | Client pen annotations on competency page — multiple issues || [`reference-preferred-tight-chart-to-norms-single-rater.png`](./reference-preferred-tight-chart-to-norms-single-rater.png) | **Preferred spacing**: single rater row — tight gap from x-axis (0–5) to GEONORM / summary row || [`reference-preferred-tight-chart-to-norms-five-raters.png`](./reference-preferred-tight-chart-to-norms-five-raters.png) | **Preferred spacing**: five rater rows — tight gap from x-axis to industry norm + group average row |
-| [`reference-preferred-tight-chart-to-norms-single-rater.png`](./reference-preferred-tight-chart-to-norms-single-rater.png) | **Preferred spacing**: single rater row — tight gap from x-axis (0–5) to GEONORM / summary row || [`client-feedback-creative-problem-solving.png`](./client-feedback-creative-problem-solving.png) | Client pen annotations on competency page — multiple issues || [`client-feedback-vertical-spacing-single-rater-markup.png`](./client-feedback-vertical-spacing-single-rater-markup.png) | **Problem (avoid)**: Creative Problem Solving, single rater — **markup** flags **too much** vertical space (legend→chart **and** axis→GEONORM). Not a “good” reference. || [`reference-preferred-tight-chart-to-norms-five-raters.png`](./reference-preferred-tight-chart-to-norms-five-raters.png) | **Preferred spacing**: five rater rows — tight gap from x-axis to industry norm + group average row |
-README.md
-+1
--1
-Reference: [`client-feedback-creative-problem-solving.png`](./client-feedback-creative-problem-solving.png)
-Reference: [`client-feedback-creative-problem-solving.png`](./client-feedback-creative-problem-solving.png)References: [`client-feedback-creative-problem-solving.png`](./client-feedback-creative-problem-solving.png) (pen), [`client-feedback-vertical-spacing-single-rater-markup.png`](./client-feedback-vertical-spacing-single-rater-markup.png) (spacing markup, single rater)
-README.md
-+1
-| Top banner arrow | (Unclear — possibly header adjustment) | Addressed (commit 22a920a) |
-| Top banner arrow | (Unclear — possibly header adjustment) | Addressed (commit 22a920a) || Vertical spacing markup (single rater) | Arrow **1**: less space between growth legend and chart; arrow **2**: less space between x-axis and GEONORM | **Pending** — see [Problem: Excessive vertical spacing](#problem-excessive-vertical-spacing-single-rater-markup) |
-Here’s what changed:
-
-Image
-Removed reference-preferred-tight-chart-to-norms-single-rater.png (it was treated as “good” but had no markup and was the wrong story).
-Added client-feedback-vertical-spacing-single-rater-markup.png from
-image-96e14c4c-67d7-4da8-830f-a73727eceaf1.png — Creative Problem Solving, single rater, with arrows for the bad spacing.
-README
-Images table: single-rater file is documented as problem / avoid, not preferred; only reference-preferred-tight-chart-to-norms-five-raters.png is called out for preferred chart-to-norms spacing.
-New section “Problem: Excessive vertical spacing (single rater, markup)”: explains this is what’s wrong, with a table for markup 1 (legend → chart) and markup 2 (axis → GEONORM) and pointers to 360-report-view-fullscreen / chart height / norms.
-“Preferred: Chart-to-norms…”: narrowed to the five-rater shot as the good reference; technical notes updated (bar-count sensitivity now cites the new markup image; added legend-to-chart note; contrast bullet lists both client-feedback PNGs vs the five-rater target).
-Client Feedback table: second reference + a Pending row for the two spacing arrows.
-So: tight “good” example = five-rater file only; single-rater with arrows = problem example with explicit markup locations.
-
-
-we need a way to export all data for a survey as system agnostic structured data. then we need a way to re-create system data from the export object.
-
-we might do this: take a snapshot, restore to the most recent backup, export the data (we need a good way to export survey data as system agonstic data anyway). at that poitn we can export the survey data as an object, then restore back to the snapshot we just took. then import the survey data export on top of that. what do you think? is that better than what you proposed? or the same?
-
-ok maybe we went a little overboard on removing whitespace. now the score labels are bunching up on the chart please advise in this md
-
-### 2026-03-20 — Report: “bunching” after tightening whitespace (chart vs norms row)
-
-**What people are seeing:** The **0–5 x-axis numbers** sit very close to—or **overlap**—the **norms row** below (“GEONORM…”, “AVG SCORE…”). It can look like the **“5” tick collides with the “GROUP” / footer text**, or that “score labels” are crammed against the chart. That’s usually **vertical clearance**, not the horizontal bar labels (Peer, Self, etc.).
-
-**Why it happened:** We removed dead space in three places: legacy `.norms { top: 70px }`, `alignItems: flex-start` on the score+chart row, and possibly smaller `margin-top` on norms. Together, the **chart’s axis band** and the **norms row** can occupy the same vertical band in the PDF/view.
-
-**What to do (pick one or combine lightly — don’t bring back the old 70px gap):**
-
-1. **Norms row:** Add a **small** top margin only if needed, e.g. `marginTop: '6px'`–`'12px'` on `div.norms` in `360-report-view-fullscreen.tsx` — enough to clear descenders/axis ticks, not a huge band.
-2. **Chart component:** In `horizontal-bar-chart.tsx` / `chart-axis-layout.ts`, bump **`X_AXIS_LABEL_GAP_PX`** slightly (e.g. +4–8px) so tick labels sit **lower** with a predictable gap above the norms row.
-3. **Norms row horizontal:** If the issue is **footer divider / text** crowding the chart grid, that’s separate from vertical tightening — norms use `max-content` + a dedicated divider; don’t confuse with axis overlap.
-
-**Principle:** Treat **axis-to-norms** as its own minimum clearance (~one line height); treat **chart-to-norms** tightening as separate from **legend-to-chart** tightening.
-
-it's still too high. so, these charts may vary in how tall they are so the scores should really be positioned directly below wherever that ends. this should fix the remaining overlap and be flexible for different chart heights. also, there appears to be two verticle divider lines between the scores now. 
-
-### 2026-03-20 — Norms under chart column + single divider (follow-up)
-
-**Request:** (1) Position GEONORM / group scores **directly below the bar chart** so variable chart heights don’t leave the footer overlapping the x-axis ticks. (2) **Two vertical lines** between the two score blocks — remove duplicate.
-
-**What we changed (involved-v2):**
-
-1. **DOM / layout:** Wrapped `HorizontalBarChart` and `div.norms` in a **column** (`flexDirection: 'column'`) inside the **chart area only** (`width: chartAreaWidth360` = 563px), beside the left score column. Norms are no longer a full-width sibling below the whole score+chart row, so they always sit **immediately under** the chart’s bottom (including axis), not under a taller flex row box.
-
-2. **Double divider:** Legacy `report-styles.css` had `.norm-group.group { border-left: 2px ... }` **and** React rendered a separate 2px divider `div`. **Removed the CSS border-left**; only the React divider remains.
-
-**Refs:** `src/components/reports/360-report-view-fullscreen.tsx`, `src/app/dashboard/reports/[assignmentId]/view/report-styles.css`, `REPORT_SPACING.chartAreaWidth360` in `report-design-constants.ts`.
-
-### 2026-03-20 — Axis ticks vs GEONORM overlap (code, not docs-only)
-
-**Issue:** 0–5 tick labels and GEONORM row were **vertically colliding** — `.bars` / `.graph` height was only `barsRegion + X_AXIS_LABEL_GAP_PX`, but tick `<span>`s sit **below** that padding with CSS `margin-top: 14px` + inline `top: 4px`, so labels extended **past** the container while the norms row started right after.
-
-**Fix (implemented):** `computeGraphContainerHeight()` adds **`X_AXIS_TICK_TEXT_RESERVE_PX` (34)** so the chart wrapper is tall enough for the full tick block. `linePaddingTop` unchanged — tick position relative to bars stays the same.
-
-**Earlier same day:** `ScoreDisplay` renamed to **`report-score-display`** so legacy `.chart .score` (`height: 230px`, `padding-top: 100px`) does not apply; that was a separate bug from axis/norms overlap.
-
-**Refs:** `src/lib/reports/chart-axis-layout.ts`, `src/components/reports/charts/horizontal-bar-chart.tsx`.
-
-### 2026-03-20 — Tighter axis ticks, centered norms, PDF duplicate divider
-
-**Feedback:** (1) 0–5 numbers still too low vs bars — want them **directly under** the axis. (2) **Center** GEONORM / group blocks on **full page** width, not only under the chart column. (3) **Double vertical lines** — second line was **`border-left` on `.norm-group.group`** in the **(reports)** PDF stylesheet, not the dashboard one.
-
-**Changes:**
-
-1. **`chart-axis-layout.ts`** — `X_AXIS_LABEL_GAP_PX` **26 → 16**; `X_AXIS_TICK_TEXT_RESERVE_PX` **34 → 22** (container still clears norms).
-2. **`horizontal-bar-chart.tsx`** — Tick `<span>` **`marginTop: 0`**, **`top: 2px`** (overrides CSS `margin-top: 14px` on `.line > span`) so labels sit tighter under the bars.
-3. **`360-report-view-fullscreen.tsx`** — Norms row **outside** the score+chart flex: full-width wrapper with **`justifyContent: 'center'`**; norms **`maxWidth: contentWidth`**, **`justifyContent: 'center'`**. **`norm-group.group`** inline **`borderLeft: 'none'`, `paddingLeft: 0`**.
-4. **`src/app/(reports)/reports/[assignmentId]/view/report-styles.css`** — Removed **`border-left`** and **`padding-left`** from `.norm-group.group` (matched dashboard; PDF had been doubling the React divider).
-
-**Refs:** `chart-axis-layout.ts`, `horizontal-bar-chart.tsx`, `360-report-view-fullscreen.tsx`, both `report-styles.css` paths.
-
-### 2026-03-20 — Score vs chart vertical center; norms divider between blocks
-
-**Feedback:** (1) Large **overall score** on the left sat **too high** — should be **vertically centered** with the bar chart. (2) **Vertical divider** between GEONORM and group scores should sit **on the midpoint** between the **two** score blocks, not offset.
-
-**Changes (`360-report-view-fullscreen.tsx`):**
-
-1. Score + chart row: **`alignItems: 'flex-start'` → `'center'`** so the score column centers against the chart height.
-2. **`score-container`:** **`alignItems: 'center'`** (was `flex-start`) so the big number is centered in its column.
-3. When **`geonorm !== null`:** norms row uses **`display: flex`** with **`flex: 1`** left and right **wrappers** — industry **`justifyContent: 'flex-end'`**, group **`justifyContent: 'flex-start'`**, fixed-width divider **between** — so the line is **horizontally centered between** the two clusters. When **`geonorm === null`**, single GEONORM block stays **centered** as before.
-
-### 2026-03-20 — Norms: more gap below chart; center cards in each half
-
-**Feedback:** (1) A bit **more space** between the **chart** and the **norms** row. (2) Divider was **geometrically** centered but looked off because the **right** card sat flush to the divider — **match** the **visual** space card-to-divider on **both** sides.
-
-**Changes (`360-report-view-fullscreen.tsx`):**
-
-1. Norms **outer** wrapper **`marginTop`**: **`8px` → `16px` → `20px`** (spacing under chart).
-2. **`geonorm`** two-column row: each **`flex: 1`** half **`justifyContent: 'center'`** (replacing **`flex-end`** / **`flex-start`**) so each **norm-group** is **centered** in its half — balanced slack **toward the divider** and **toward the outer** margin.
-
-review the changes we just made in involved.md and in the staged and unstaged changes and commit, push and deploy staging.
-
-we're looking good. so, i was wrong about the dimension definitions. they do in fact need to be rich text. change the fields on the assessment edit interface to support rich text and make sure they are parsing the tags in the report.
-
-ok this is interesting. i just updated one of the dimension descriptions and suddenly all of the answer data for the survey got nuked. please investigate.
-
-so once assignments are created, their assessment needs to be locked. the user needs to be warned that by editing assessments after assignment, they risk causing data inaccuracy. in the reports. it needs to be a warning like "this assessment is currently being used in active surveys. editing it may cause data inaccuracies. are you sure you want to continue?"
-
-we may actually want to include in the message that they may want to save a survey snapshot before editing. 
-
-i like the lock on the assessment edit page. we should add a lock icon next to the assessment in the assessment index page with a more brief tooltip message.
-
-### 2026-03-20 — PDF page numbers too high vs HTML
-
-**Cause:** Both **`export-pdf-puppeteer.ts`** and **`export-pdf-playwright.ts`** inject print CSS with **`.page-footer { bottom: 0 !important; }`**. **`PageFooter`** uses inline **`bottom: '-110px'`** (positions the label in the band below **`.page-wrapper`**). **`!important` beats inline**, so **PDF** pinned the footer to **`bottom: 0`** while **HTML** kept **`-110px`** — page numbers looked **too high** in the PDF.
-
-**Fix:** Dropped **`bottom: 0 !important`** from **`.page-footer`** in both exporters (kept **`position: absolute !important`** only). **Puppeteer** also aligned **`.page-wrapper { padding-bottom }`** **59px → 64px** to match **`PageWrapper`** / Playwright (**`footerAreaHeight`**). **`page-footer.tsx`:** **`fontFamily`** was incorrectly set to **`fontSize`**; set to the report Helvetica stack.
-
-**Refs:** `src/lib/reports/export-pdf-puppeteer.ts`, `src/lib/reports/export-pdf-playwright.ts`, `src/components/reports/layout/page-footer.tsx`.
+we have tools to analyze video. start with a whisper transcript. then you can use the mmfpeg and python to select and analyze frames based on the analysis of the transcript by timestamps provided by whisper. use the gus-claw memory tool to review the last time we did something similar. it was just a few days ago.

--- a/src/app/api/assignments/route.ts
+++ b/src/app/api/assignments/route.ts
@@ -350,11 +350,39 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // Generate or use provided survey_id for this batch of assignments
-    // All assignments created in this API call will share the same survey_id
-    // If survey_id is provided, use it (for adding to existing survey)
-    // Otherwise, generate a new one
-    const surveyId = survey_id || randomUUID()
+    // Resolve or create survey
+    let surveyId: string
+    if (survey_id) {
+      // Adding to existing survey — validate it exists
+      const { data: existingSurvey } = await adminClient
+        .from('surveys')
+        .select('id')
+        .eq('id', survey_id)
+        .single()
+      if (!existingSurvey) {
+        return NextResponse.json({ error: 'Survey not found' }, { status: 404 })
+      }
+      surveyId = survey_id
+    } else {
+      // Create a new survey
+      // Derive client_id from group or first user
+      const clientId = group_id
+        ? (await adminClient.from('groups').select('client_id').eq('id', group_id).single()).data?.client_id
+        : actorProfile.client_id
+      const { data: newSurvey, error: surveyError } = await adminClient
+        .from('surveys')
+        .insert({
+          client_id: clientId,
+          assessment_id: assessment_ids[0],
+          created_by: user.id,
+        })
+        .select('id')
+        .single()
+      if (surveyError || !newSurvey) {
+        return NextResponse.json({ error: 'Failed to create survey: ' + (surveyError?.message || 'Unknown') }, { status: 500 })
+      }
+      surveyId = newSurvey.id
+    }
 
     // When adding to an existing survey, reject if any requested user already has an
     // identical assignment (same user + assessment + target) in this survey.

--- a/src/app/api/assignments/route.ts
+++ b/src/app/api/assignments/route.ts
@@ -580,6 +580,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(
       {
         success: true,
+        survey_id: surveyId,
         assignments: assignments.map((a) => ({
           ...a,
           url: assignmentUrls.find((au) => au.id === a.id)?.url,

--- a/src/app/api/assignments/send-batch-email/route.ts
+++ b/src/app/api/assignments/send-batch-email/route.ts
@@ -145,17 +145,17 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  // Don't await — let emails send in the background
-  // Vercel keeps the function alive for ongoing promises even after responding
-  Promise.allSettled(emailPromises).then(results => {
-    const sent = results.filter(r => r.status === 'fulfilled').length
-    const failed = results.filter(r => r.status === 'rejected').length
-    console.log(`[Batch Email] Completed: ${sent} sent, ${failed} failed out of ${results.length}`)
-  })
+  // Send all emails in parallel and wait for completion
+  const results = await Promise.allSettled(emailPromises)
+  const sent = results.filter(r => r.status === 'fulfilled').length
+  const failed = results.filter(r => r.status === 'rejected').length
+  console.log(`[Batch Email] Completed: ${sent} sent, ${failed} failed out of ${results.length}`)
 
   return NextResponse.json({
     success: true,
-    queued: byUser.size,
-    message: `${byUser.size} email(s) queued for delivery`,
+    sent,
+    failed,
+    total: byUser.size,
+    message: `${sent} email(s) sent${failed > 0 ? `, ${failed} failed` : ''}`,
   })
 }

--- a/src/app/api/assignments/send-batch-email/route.ts
+++ b/src/app/api/assignments/send-batch-email/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+import { getAppUrl } from '@/lib/config'
+import { sendEmail } from '@/lib/services/email-service'
+
+interface BatchEmailRequest {
+  assignment_ids: string[]
+  subject?: string
+  body?: string
+  passwords?: Record<string, string> // user_id -> password
+}
+
+/**
+ * POST /api/assignments/send-batch-email
+ * Server-side batch email sending for assignment notifications.
+ * Fires all emails without blocking the client — returns immediately
+ * with a job ID, sends emails in the background.
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const body: BatchEmailRequest = await request.json()
+  const { assignment_ids, subject, body: emailBody, passwords } = body
+
+  if (!assignment_ids || assignment_ids.length === 0) {
+    return NextResponse.json({ error: 'assignment_ids required' }, { status: 400 })
+  }
+
+  const adminClient = createAdminClient()
+
+  // Fetch all assignments with user and assessment info
+  const { data: assignments } = await adminClient
+    .from('assignments')
+    .select(`
+      id, user_id, assessment_id, url, expires,
+      user:profiles!assignments_user_id_fkey(id, name, email, username),
+      assessment:assessments!assignments_assessment_id_fkey(id, title)
+    `)
+    .in('id', assignment_ids)
+
+  if (!assignments || assignments.length === 0) {
+    return NextResponse.json({ error: 'No assignments found' }, { status: 404 })
+  }
+
+  // Group assignments by user for consolidated emails
+  const byUser = new Map<string, {
+    user: { name: string; email: string; username: string }
+    assignments: Array<{ assessmentTitle: string; url?: string | null; expires?: string | null }>
+  }>()
+
+  for (const a of assignments) {
+    const u = (a.user as unknown) as { id: string; name: string; email: string; username: string } | null
+    const assess = (a.assessment as unknown) as { title: string } | null
+    if (!u) continue
+
+    if (!byUser.has(u.id)) {
+      byUser.set(u.id, { user: u, assignments: [] })
+    }
+    byUser.get(u.id)!.assignments.push({
+      assessmentTitle: assess?.title || 'Assessment',
+      url: a.url,
+      expires: a.expires,
+    })
+  }
+
+  const baseUrl = getAppUrl()
+  const dashboardLink = `${baseUrl}/dashboard`
+  const year = new Date().getFullYear()
+
+  const defaultSubject = subject || 'New assessments have been assigned to you'
+  const defaultBody = emailBody || 'Hello {name}, you have been assigned {assessments}. Please complete by {expiration-date}. Dashboard: {dashboard-link}. © {year} Involved Talent.'
+
+  // Send emails — fire and forget (don't await, let them complete in background)
+  const emailPromises: Promise<void>[] = []
+
+  for (const [userId, data] of byUser) {
+    const { user: u, assignments: userAssignments } = data
+    const password = passwords?.[userId]
+    const assessmentList = userAssignments.map(a => a.assessmentTitle).join(', ')
+    const firstExpires = userAssignments[0]?.expires
+    const expirationStr = firstExpires ? new Date(firstExpires).toLocaleDateString() : 'N/A'
+
+    // Build assignment links HTML
+    const assignmentLinksHtml = userAssignments.map(a => {
+      const link = a.url ? `<a href="${a.url}">${a.assessmentTitle}</a>` : a.assessmentTitle
+      return `<li>${link}</li>`
+    }).join('')
+
+    // Replace shortcodes
+    let processedBody = defaultBody
+      .replace(/{name}/g, u.name)
+      .replace(/{username}/g, u.username || u.email)
+      .replace(/{email}/g, u.email)
+      .replace(/{assessments}/g, assessmentList)
+      .replace(/{expiration-date}/g, expirationStr)
+      .replace(/{dashboard-link}/g, dashboardLink)
+      .replace(/{year}/g, String(year))
+
+    if (password) {
+      processedBody = processedBody.replace(/{password}/g, password)
+    } else {
+      processedBody = processedBody.replace(/{password}/g, '')
+    }
+
+    const htmlBody = `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <div style="background-color: #2D2E30; color: #ffffff; padding: 20px; text-align: center;">
+          <h2 style="margin: 0; color: #ffffff;">Assessment Notification</h2>
+        </div>
+        <div style="padding: 20px;">
+          ${processedBody.split('\n').map(line => `<p>${line}</p>`).join('')}
+          ${assignmentLinksHtml ? `<ul>${assignmentLinksHtml}</ul>` : ''}
+          ${password ? `<p style="background: #f3f4f6; padding: 12px; border-radius: 4px;"><strong>Your temporary password:</strong> ${password}</p>` : ''}
+          <p><a href="${dashboardLink}" style="background-color: #FFBA00; color: #2D2E30; padding: 12px 24px; text-decoration: none; border-radius: 4px; display: inline-block; font-weight: bold;">Go to Dashboard</a></p>
+        </div>
+        <div style="padding: 16px 20px; border-top: 1px solid #ddd; font-size: 12px; color: #666;">
+          &copy; ${year} Involved Talent
+        </div>
+      </div>
+    `
+
+    const textBody = processedBody
+
+    emailPromises.push(
+      sendEmail(u.email, defaultSubject, htmlBody, textBody, {
+        logMetadata: {
+          emailType: 'assignment',
+          relatedEntityType: 'assignment',
+          relatedEntityId: assignment_ids.find(id =>
+            assignments.find(a => a.id === id && ((a.user as unknown) as { id: string })?.id === userId)
+          ) || null,
+        },
+      }).then(result => {
+        if (!result.success) {
+          console.error(`Failed to send email to ${u.email}:`, result.error)
+        }
+      }).catch(err => {
+        console.error(`Error sending email to ${u.email}:`, err)
+      })
+    )
+  }
+
+  // Don't await — let emails send in the background
+  // Vercel keeps the function alive for ongoing promises even after responding
+  Promise.allSettled(emailPromises).then(results => {
+    const sent = results.filter(r => r.status === 'fulfilled').length
+    const failed = results.filter(r => r.status === 'rejected').length
+    console.log(`[Batch Email] Completed: ${sent} sent, ${failed} failed out of ${results.length}`)
+  })
+
+  return NextResponse.json({
+    success: true,
+    queued: byUser.size,
+    message: `${byUser.size} email(s) queued for delivery`,
+  })
+}

--- a/src/app/api/clients/[id]/surveys/[surveyId]/export-csv/route.ts
+++ b/src/app/api/clients/[id]/surveys/[surveyId]/export-csv/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { exportSurveyRawCSV } from '@/lib/reports/export-survey-csv'
+
+/**
+ * GET /api/clients/[id]/surveys/[surveyId]/export-csv
+ * Export raw survey data as CSV (individual user responses)
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string; surveyId: string }> }
+) {
+  const { id: clientId, surveyId } = await params
+  const supabase = await createClient()
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Verify user has access to this client
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('access_level, client_id')
+    .eq('auth_user_id', user.id)
+    .single()
+
+  if (!profile) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const isSuperAdmin = profile.access_level === 'super_admin'
+  if (!isSuperAdmin && profile.client_id !== clientId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  try {
+    const csv = await exportSurveyRawCSV(surveyId)
+    return new Response(csv, {
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="survey-${surveyId.substring(0, 8)}-raw-data.csv"`,
+      },
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Export failed' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/clients/[id]/surveys/[surveyId]/route.ts
+++ b/src/app/api/clients/[id]/surveys/[surveyId]/route.ts
@@ -55,11 +55,11 @@ export async function PATCH(
     }
 
     const body = await request.json()
-    const { expires, delete_assignment_ids } = body
+    const { expires, delete_assignment_ids, reminder, reminder_frequency, first_reminder_date } = body
 
-    if (!expires && !delete_assignment_ids) {
+    if (!expires && !delete_assignment_ids && reminder === undefined) {
       return NextResponse.json(
-        { error: 'No valid fields to update. Provide expires or delete_assignment_ids.' },
+        { error: 'No valid fields to update.' },
         { status: 400 }
       )
     }
@@ -128,6 +128,43 @@ export async function PATCH(
       }
 
       result.updated_assignments = count ?? surveyAssignmentIds.length
+    }
+
+    // Batch update reminders (only for incomplete assignments)
+    if (reminder !== undefined) {
+      const updateData: Record<string, unknown> = {
+        reminder: !!reminder,
+      }
+
+      if (reminder) {
+        // Calculate next_reminder
+        if (first_reminder_date) {
+          updateData.next_reminder = new Date(first_reminder_date).toISOString()
+        } else {
+          // Default: tomorrow at 9 AM UTC
+          const tomorrow = new Date()
+          tomorrow.setDate(tomorrow.getDate() + 1)
+          tomorrow.setUTCHours(9, 0, 0, 0)
+          updateData.next_reminder = tomorrow.toISOString()
+        }
+        updateData.reminder_frequency = reminder_frequency || '+3 days'
+      } else {
+        updateData.next_reminder = null
+        updateData.reminder_frequency = null
+      }
+
+      const { error: reminderError, count } = await adminClient
+        .from('assignments')
+        .update(updateData)
+        .in('id', surveyAssignmentIds)
+        .eq('completed', false)
+
+      if (reminderError) {
+        console.error('Error updating reminders:', reminderError)
+        return NextResponse.json({ error: 'Failed to update reminders' }, { status: 500 })
+      }
+
+      result.updated_assignments = (result.updated_assignments || 0) + (count ?? 0)
     }
 
     // Batch delete specific assignments

--- a/src/app/api/reports/[assignmentId]/export/pdf/route.ts
+++ b/src/app/api/reports/[assignmentId]/export/pdf/route.ts
@@ -110,7 +110,7 @@ export async function GET(
     // Construct the fullscreen view URL (using the route group path, no dashboard layout)
     // If service role authentication, add token to query parameter for view page
     const viewUrl = isServiceRole 
-      ? `${baseUrl}/reports/${assignmentId}/view?service_role_token=${encodeURIComponent(normalizedServiceKey!)}`
+      ? `${baseUrl}/reports/${assignmentId}/view?service_role_token=${encodeURIComponent(serviceRoleKey!)}`
       : `${baseUrl}/reports/${assignmentId}/view`
 
     // Generate PDF from the fullscreen view

--- a/src/app/api/reports/[assignmentId]/export/pdf/route.ts
+++ b/src/app/api/reports/[assignmentId]/export/pdf/route.ts
@@ -29,14 +29,12 @@ export async function GET(
     const authHeader = request.headers.get('authorization')
     const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
-    // Normalize both strings for comparison (trim whitespace)
-    const normalizedAuthHeader = authHeader?.trim()
-    const normalizedServiceKey = serviceRoleKey?.trim()
-    const expectedAuthHeader = normalizedServiceKey ? `Bearer ${normalizedServiceKey}` : null
-
-    const isServiceRole = normalizedAuthHeader?.startsWith('Bearer ') &&
-                         normalizedServiceKey &&
-                         normalizedAuthHeader === expectedAuthHeader
+    // Check for service role: compare Bearer token against our service role key
+    let isServiceRole = false
+    if (authHeader && serviceRoleKey) {
+      const token = authHeader.replace(/^Bearer\s+/i, '').trim()
+      isServiceRole = token === serviceRoleKey.trim()
+    }
 
     if (!isServiceRole) {
       const {
@@ -45,6 +43,10 @@ export async function GET(
       } = await supabase.auth.getUser()
 
       if (authError || !user) {
+        console.error('[PDF Export] Auth failed. isServiceRole:', isServiceRole,
+          'authHeader present:', !!authHeader,
+          'authHeader length:', authHeader?.length,
+          'serviceRoleKey length:', serviceRoleKey?.length)
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
       }
     }

--- a/src/app/api/reports/[assignmentId]/pdf/route.ts
+++ b/src/app/api/reports/[assignmentId]/pdf/route.ts
@@ -154,14 +154,24 @@ export async function POST(
       )
     }
 
-    // Ensure report_data exists (create if not)
-    if (!currentReportData) {
-      await adminClient
-        .from('report_data')
-        .insert({
-          assignment_id: assignmentId,
-          dimension_scores: {},
-        })
+    // Ensure report_data exists with actual report content (not just a stub)
+    if (!currentReportData || !currentReportData.assignment_id) {
+      // Generate the report first so the view page has data to render
+      const generateUrl = new URL(`/api/reports/generate/${assignmentId}`, request.url)
+      const generateRes = await fetch(generateUrl.toString(), {
+        method: 'POST',
+        headers: {
+          'Cookie': request.headers.get('cookie') || '',
+          'Content-Type': 'application/json',
+        },
+      })
+      if (!generateRes.ok) {
+        const errData = await generateRes.json().catch(() => ({}))
+        return NextResponse.json(
+          { error: 'Report must be generated before PDF export', details: errData.error },
+          { status: 400 }
+        )
+      }
     }
 
     // Generate job ID for tracking

--- a/src/app/api/surveys/route.ts
+++ b/src/app/api/surveys/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+/**
+ * POST /api/surveys
+ * Create a new survey (returns the survey ID for subsequent assignment creation)
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient()
+  const { data: { user }, error: authError } = await supabase.auth.getUser()
+  if (authError || !user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { client_id, assessment_id, name } = await request.json()
+  if (!client_id || !assessment_id) {
+    return NextResponse.json({ error: 'client_id and assessment_id are required' }, { status: 400 })
+  }
+
+  const adminClient = createAdminClient()
+  const { data: survey, error } = await adminClient
+    .from('surveys')
+    .insert({
+      client_id,
+      assessment_id,
+      name: name || null,
+      created_by: user.id,
+    })
+    .select('id')
+    .single()
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+
+  return NextResponse.json({ survey_id: survey.id })
+}

--- a/src/app/api/surveys/simulate/route.ts
+++ b/src/app/api/surveys/simulate/route.ts
@@ -135,7 +135,24 @@ async function runSimulation(
   const assignmentIds: string[] = []
   const expiresAt = new Date()
   expiresAt.setDate(expiresAt.getDate() + 30)
-  const surveyId = crypto.randomUUID()
+
+  // Create a survey row
+  const { data: newSurvey, error: surveyError } = await adminClient
+    .from('surveys')
+    .insert({
+      client_id: group.client_id,
+      assessment_id: assessment_id,
+      created_by: user.id,
+    })
+    .select('id')
+    .single()
+
+  if (surveyError || !newSurvey) {
+    writeLine(JSON.stringify({ done: true, error: 'Failed to create survey: ' + (surveyError?.message || 'Unknown') }))
+    return
+  }
+  const surveyId = newSurvey.id
+  writeLine(`Created survey ${surveyId.slice(0, 8)}...`)
 
   // Randomize completion: always leave at least 1 incomplete, cap at 98%
   const maxComplete = Math.min(

--- a/src/app/dashboard/assessments/[id]/edit/edit-client.tsx
+++ b/src/app/dashboard/assessments/[id]/edit/edit-client.tsx
@@ -171,26 +171,16 @@ export default function EditAssessmentClient({ id }: EditAssessmentClientProps) 
           show_question_numbers: assessment.show_question_numbers !== undefined ? assessment.show_question_numbers : true,
           use_custom_fields: assessment.use_custom_fields ?? false,
           custom_fields: customFields,
-          dimensions: (() => {
-            // Build definition map from rich_text fields
-            const definitionMap = new Map<string, string>()
-            ;(fields || []).forEach(f => {
-              if (f.type === 'rich_text' && f.dimension_id) {
-                definitionMap.set(f.dimension_id, f.content || '')
-              }
-            })
-            return (dimensions || []).map(dim => ({
-              id: dim.id,
-              name: dim.name,
-              code: dim.code,
-              parent_id: dim.parent_id,
-              definition: definitionMap.get(dim.id) || '',
-            }))
-          })(),
+          dimensions: (dimensions || []).map(dim => ({
+            id: dim.id,
+            name: dim.name,
+            code: dim.code,
+            parent_id: dim.parent_id,
+            definition: (dim as Record<string, unknown>).definition as string || '',
+          })),
           // Map fields preserving the order from the database query
           // The fields are already sorted by 'order' column, so we preserve that order
-          // Filter out rich_text fields (dimension definitions) — they are loaded into dimensions above
-          fields: (fields || []).filter(f => f.type !== 'rich_text').map((field, index) => {
+          fields: (fields || []).map((field, index) => {
             type FieldRow = Database['public']['Tables']['fields']['Row']
             const fieldWithExtras = field as FieldRow & { number?: number; practice?: boolean; required?: boolean }
             return {
@@ -518,9 +508,6 @@ export default function EditAssessmentClient({ id }: EditAssessmentClientProps) 
         const formDimDbIds = new Set(validDims.map(d => tempIdToDbIdMap.get(d.id) || d.id))
         const dimsToDelete = [...existingDimIds].filter(dbId => !formDimDbIds.has(dbId))
         if (dimsToDelete.length > 0) {
-          // Before deleting dimensions, delete their definition fields (rich_text)
-          // so we don't leave orphan fields. This is safe — rich_text fields have no answers.
-          await supabase.from('fields').delete().eq('assessment_id', id).eq('type', 'rich_text').in('dimension_id', dimsToDelete)
           const { error } = await supabase.from('dimensions').delete().in('id', dimsToDelete)
           if (error) throw new Error(`Failed to delete removed dimensions: ${error.message}`)
         }
@@ -604,10 +591,9 @@ export default function EditAssessmentClient({ id }: EditAssessmentClientProps) 
           if (error) throw new Error(`Failed to insert new fields: ${error.message}`)
         }
 
-        // Delete only fields that were removed from the form (NOT rich_text — handled below)
+        // Delete only fields that were removed from the form
         const formFieldDbIds = new Set(formFields.map(f => f.id).filter(fid => existingFieldIds.has(fid)))
-        const existingNonRichText = (existingFields || []).filter(f => f.type !== 'rich_text')
-        const fieldsToDelete = existingNonRichText.filter(f => !formFieldDbIds.has(f.id)).map(f => f.id)
+        const fieldsToDelete = (existingFields || []).filter(f => !formFieldDbIds.has(f.id)).map(f => f.id)
         if (fieldsToDelete.length > 0) {
           // WARNING: This will CASCADE delete answers for these fields.
           // Only reaches here if the user explicitly removed a question from the form.
@@ -617,46 +603,11 @@ export default function EditAssessmentClient({ id }: EditAssessmentClientProps) 
         }
       }
 
-      // ─── Dimension definitions (rich_text fields): upsert by dimension_id ───
-      {
-        const existingDefFields = (existingFields || []).filter(f => f.type === 'rich_text')
-        const existingDefByDimId = new Map(existingDefFields.map(f => [f.dimension_id, f]))
-
-        for (const dim of data.dimensions) {
-          const dbDimId = tempIdToDbIdMap.get(dim.id) || dim.id
-          const definition = dim.definition?.trim() || ''
-          const existing = existingDefByDimId.get(dbDimId)
-
-          if (definition && existing) {
-            // Update existing definition field
-            if (existing.content !== definition) {
-              await supabase.from('fields').update({ content: definition }).eq('id', existing.id)
-            }
-            existingDefByDimId.delete(dbDimId) // Mark as handled
-          } else if (definition && !existing) {
-            // Insert new definition field
-            await supabase.from('fields').insert({
-              assessment_id: id,
-              dimension_id: dbDimId,
-              type: 'rich_text' as const,
-              content: definition,
-              order: 0,
-              number: 0,
-              required: false,
-              practice: false,
-              anchors: [],
-            })
-          } else if (!definition && existing) {
-            // Definition cleared — delete the rich_text field (safe, no answers reference rich_text)
-            await supabase.from('fields').delete().eq('id', existing.id)
-            existingDefByDimId.delete(dbDimId)
-          }
-        }
-
-        // Delete orphan definition fields for dimensions that no longer exist
-        for (const [, orphanDef] of existingDefByDimId) {
-          await supabase.from('fields').delete().eq('id', orphanDef.id)
-        }
+      // ─── Dimension definitions: update directly on dimensions table ───
+      for (const dim of data.dimensions) {
+        const dbDimId = tempIdToDbIdMap.get(dim.id) || dim.id
+        const definition = dim.definition?.trim() || null
+        await supabase.from('dimensions').update({ definition }).eq('id', dbDimId)
       }
 
       // Map dimension_question_counts from temporary IDs to database UUIDs

--- a/src/app/dashboard/assessments/[id]/edit/edit-client.tsx
+++ b/src/app/dashboard/assessments/[id]/edit/edit-client.tsx
@@ -180,7 +180,8 @@ export default function EditAssessmentClient({ id }: EditAssessmentClientProps) 
           })),
           // Map fields preserving the order from the database query
           // The fields are already sorted by 'order' column, so we preserve that order
-          fields: (fields || []).map((field, index) => {
+          // Filter out rich_text definition fields (dimension_id set) — definitions now live on dimensions table
+          fields: (fields || []).filter(f => !(f.type === 'rich_text' && f.dimension_id)).map((field, index) => {
             type FieldRow = Database['public']['Tables']['fields']['Row']
             const fieldWithExtras = field as FieldRow & { number?: number; practice?: boolean; required?: boolean }
             return {

--- a/src/app/dashboard/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/assignments/create/create-assignment-client.tsx
@@ -325,6 +325,25 @@ export default function CreateAssignmentClient() {
       const expiresDate = new Date(expirationDate)
       expiresDate.setHours(23, 59, 59, 999)
 
+      // Create or use existing survey
+      let surveyId: string | undefined = existingSurveyId || undefined
+      if (!surveyId && selectedAssessmentIds.length > 0) {
+        // Derive client_id from first user's profile
+        const firstUser = assignmentUsers[0]?.user
+        const clientId = firstUser?.client_id
+        if (clientId) {
+          const surveyRes = await fetch('/api/surveys', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ client_id: clientId, assessment_id: selectedAssessmentIds[0] }),
+          })
+          const surveyData = await surveyRes.json()
+          if (surveyRes.ok && surveyData.survey_id) {
+            surveyId = surveyData.survey_id
+          }
+        }
+      }
+
       // Create assignments for each user
       // Since each user can have different target_id and custom_fields,
       // we make one API call per user with all their assessments
@@ -364,9 +383,7 @@ export default function CreateAssignmentClient() {
           custom_fields: customFields,
           whitelabel: false,
         }
-        if (existingSurveyId) {
-          body.survey_id = existingSurveyId
-        }
+        body.survey_id = surveyId
         const promise = fetch('/api/assignments', {
           method: 'POST',
           headers: {

--- a/src/app/dashboard/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/assignments/create/create-assignment-client.tsx
@@ -141,32 +141,44 @@ export default function CreateAssignmentClient() {
           }
         }
 
-        // Load assignments to build existing surveys list (for "Add to existing survey" dropdown)
-        const assignmentsRes = await fetch('/api/assignments')
-        const assignmentsData = await assignmentsRes.json().catch(() => ({}))
-        const allAssignments = Array.isArray(assignmentsData.assignments) ? assignmentsData.assignments : []
-        const bySurvey = new Map<string, { assessment_ids: Set<string>; expires: string; user_ids: Set<string>; assessmentTitles: string[] }>()
-        for (const a of allAssignments as Array<{ survey_id: string | null; assessment_id: string; user_id: string; expires: string; assessment?: { title?: string } }>) {
-          if (!a.survey_id) continue
-          if (!bySurvey.has(a.survey_id)) {
-            bySurvey.set(a.survey_id, { assessment_ids: new Set(), expires: a.expires, user_ids: new Set(), assessmentTitles: [] })
-          }
-          const g = bySurvey.get(a.survey_id)!
-          g.assessment_ids.add(a.assessment_id)
-          g.user_ids.add(a.user_id)
-          if (a.assessment?.title && !g.assessmentTitles.includes(a.assessment.title)) {
-            g.assessmentTitles.push(a.assessment.title)
-          }
+        // Load existing surveys from the surveys table
+        const { data: surveysData } = await supabase
+          .from('surveys')
+          .select(`
+            id,
+            name,
+            assessment_id,
+            created_at,
+            assessment:assessments!surveys_assessment_id_fkey(id, title)
+          `)
+          .order('created_at', { ascending: false })
+
+        // Get assignment stats per survey for the label
+        const surveyIds = (surveysData || []).map(s => s.id)
+        let assignmentStats: Array<{ survey_id: string; user_id: string; expires: string }> = []
+        if (surveyIds.length > 0) {
+          const { data: statsData } = await supabase
+            .from('assignments')
+            .select('survey_id, user_id, expires')
+            .in('survey_id', surveyIds)
+          assignmentStats = statsData || []
         }
-        const surveys: SurveyOption[] = []
-        bySurvey.forEach((g, survey_id) => {
-          const assessment_ids = Array.from(g.assessment_ids)
-          const user_ids = Array.from(g.user_ids)
-          const expiresDate = g.expires.slice(0, 10)
-          const label = g.assessmentTitles.length
-            ? `${g.assessmentTitles[0]}${g.assessmentTitles.length > 1 ? ` (+${g.assessmentTitles.length - 1} more)` : ''} – expires ${expiresDate} – ${user_ids.length} participant${user_ids.length !== 1 ? 's' : ''}`
-            : `Survey – expires ${expiresDate} – ${user_ids.length} participant${user_ids.length !== 1 ? 's' : ''}`
-          surveys.push({ survey_id, assessment_ids, expires: g.expires, user_ids, label })
+
+        const surveys: SurveyOption[] = (surveysData || []).map(s => {
+          const assessment = s.assessment as unknown as { id: string; title: string } | null
+          const surveyAssignments = assignmentStats.filter(a => a.survey_id === s.id)
+          const uniqueUserIds = [...new Set(surveyAssignments.map(a => a.user_id))]
+          const expires = surveyAssignments[0]?.expires || ''
+          const expiresDate = expires ? expires.slice(0, 10) : 'no expiry'
+          const title = s.name || assessment?.title || 'Survey'
+          const label = `${title} – expires ${expiresDate} – ${uniqueUserIds.length} participant${uniqueUserIds.length !== 1 ? 's' : ''}`
+          return {
+            survey_id: s.id,
+            assessment_ids: [s.assessment_id],
+            expires,
+            user_ids: uniqueUserIds,
+            label,
+          }
         })
         setSurveysList(surveys)
 

--- a/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
@@ -444,7 +444,7 @@ export default function CreateAssignmentClient({ clientId }: CreateAssignmentCli
                 whitelabel: false,
                 survey_id: surveyId, // All assignments in this batch share the same survey_id
                 reminder: enableReminder,
-                first_reminder_date: enableReminder && firstReminderDate ? `${firstReminderDate}T${firstReminderTime}:00` : null,
+                first_reminder_date: enableReminder && firstReminderDate ? new Date(`${firstReminderDate}T${firstReminderTime}`).toISOString() : null,
                 reminder_frequency: enableReminder ? reminderFrequency : null,
               }),
             })

--- a/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
@@ -173,32 +173,45 @@ export default function CreateAssignmentClient({ clientId }: CreateAssignmentCli
           setAvailableGroups(transformedGroups)
         }
 
-        // Load assignments to build existing surveys list (for "Add to existing survey" dropdown)
-        const assignmentsRes = await fetch('/api/assignments')
-        const assignmentsData = await assignmentsRes.json().catch(() => ({}))
-        const allAssignments = Array.isArray(assignmentsData.assignments) ? assignmentsData.assignments : []
-        const bySurvey = new Map<string, { assessment_ids: Set<string>; expires: string; user_ids: Set<string>; assessmentTitles: string[] }>()
-        for (const a of allAssignments as Array<{ survey_id: string | null; assessment_id: string; user_id: string; expires: string; assessment?: { title?: string } }>) {
-          if (!a.survey_id) continue
-          if (!bySurvey.has(a.survey_id)) {
-            bySurvey.set(a.survey_id, { assessment_ids: new Set(), expires: a.expires, user_ids: new Set(), assessmentTitles: [] })
-          }
-          const g = bySurvey.get(a.survey_id)!
-          g.assessment_ids.add(a.assessment_id)
-          g.user_ids.add(a.user_id)
-          if (a.assessment?.title && !g.assessmentTitles.includes(a.assessment.title)) {
-            g.assessmentTitles.push(a.assessment.title)
-          }
+        // Load existing surveys from the surveys table (scoped to this client)
+        const { data: surveysData } = await supabase
+          .from('surveys')
+          .select(`
+            id,
+            name,
+            assessment_id,
+            created_at,
+            assessment:assessments!surveys_assessment_id_fkey(id, title)
+          `)
+          .eq('client_id', clientId)
+          .order('created_at', { ascending: false })
+
+        // Get assignment stats per survey for the label
+        const surveyIds = (surveysData || []).map(s => s.id)
+        let assignmentStats: Array<{ survey_id: string; user_id: string; expires: string }> = []
+        if (surveyIds.length > 0) {
+          const { data: statsData } = await supabase
+            .from('assignments')
+            .select('survey_id, user_id, expires')
+            .in('survey_id', surveyIds)
+          assignmentStats = statsData || []
         }
-        const surveys: SurveyOption[] = []
-        bySurvey.forEach((g, survey_id) => {
-          const assessment_ids = Array.from(g.assessment_ids)
-          const user_ids = Array.from(g.user_ids)
-          const expiresDate = g.expires.slice(0, 10)
-          const label = g.assessmentTitles.length
-            ? `${g.assessmentTitles[0]}${g.assessmentTitles.length > 1 ? ` (+${g.assessmentTitles.length - 1} more)` : ''} – expires ${expiresDate} – ${user_ids.length} participant${user_ids.length !== 1 ? 's' : ''}`
-            : `Survey – expires ${expiresDate} – ${user_ids.length} participant${user_ids.length !== 1 ? 's' : ''}`
-          surveys.push({ survey_id, assessment_ids, expires: g.expires, user_ids, label })
+
+        const surveys: SurveyOption[] = (surveysData || []).map(s => {
+          const assessment = s.assessment as unknown as { id: string; title: string } | null
+          const surveyAssignments = assignmentStats.filter(a => a.survey_id === s.id)
+          const uniqueUserIds = [...new Set(surveyAssignments.map(a => a.user_id))]
+          const expires = surveyAssignments[0]?.expires || ''
+          const expiresDate = expires ? expires.slice(0, 10) : 'no expiry'
+          const title = s.name || assessment?.title || 'Survey'
+          const label = `${title} – expires ${expiresDate} – ${uniqueUserIds.length} participant${uniqueUserIds.length !== 1 ? 's' : ''}`
+          return {
+            survey_id: s.id,
+            assessment_ids: [s.assessment_id],
+            expires,
+            user_ids: uniqueUserIds,
+            label,
+          }
         })
         setSurveysList(surveys)
 

--- a/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
@@ -389,8 +389,8 @@ export default function CreateAssignmentClient({ clientId }: CreateAssignmentCli
       const expiresDate = new Date(expirationDate)
       expiresDate.setHours(23, 59, 59, 999) // Set to end of day
 
-      // Use existing survey_id when adding to a survey, otherwise generate a new one
-      const surveyId = existingSurveyId || crypto.randomUUID()
+      // Use existing survey_id when adding to a survey, otherwise let the API create one
+      const surveyId = existingSurveyId || undefined
 
       // Create assignments using API - one API call per user-assessment combination
       // This allows per-user custom_fields and target_id

--- a/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
@@ -389,8 +389,22 @@ export default function CreateAssignmentClient({ clientId }: CreateAssignmentCli
       const expiresDate = new Date(expirationDate)
       expiresDate.setHours(23, 59, 59, 999) // Set to end of day
 
-      // Use existing survey_id when adding to a survey, otherwise let the API create one
-      const surveyId = existingSurveyId || undefined
+      // Use existing survey_id when adding to a survey, otherwise create one upfront
+      let surveyId: string | undefined = existingSurveyId || undefined
+      if (!surveyId) {
+        const surveyRes = await fetch('/api/surveys', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ client_id: clientId, assessment_id: selectedAssessmentIds[0] }),
+        })
+        const surveyData = await surveyRes.json()
+        if (!surveyRes.ok || !surveyData.survey_id) {
+          setMessage('Failed to create survey: ' + (surveyData.error || 'Unknown error'))
+          setIsSubmitting(false)
+          return
+        }
+        surveyId = surveyData.survey_id
+      }
 
       // Create assignments using API - one API call per user-assessment combination
       // This allows per-user custom_fields and target_id

--- a/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
@@ -522,7 +522,7 @@ export default function CreateAssignmentClient({ clientId }: CreateAssignmentCli
           })
           const batchData = await batchRes.json()
           if (batchRes.ok) {
-            setMessage(prev => prev + (prev ? ' ' : '') + `✅ ${batchData.queued} email notification(s) queued for delivery.`)
+            setMessage(prev => prev + (prev ? ' ' : '') + `✅ ${batchData.message}`)
           } else {
             setMessage(prev => prev + (prev ? ' ' : '') + `⚠️ Email queuing failed: ${batchData.error}`)
           }

--- a/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
+++ b/src/app/dashboard/clients/[id]/assignments/create/create-assignment-client.tsx
@@ -507,127 +507,28 @@ export default function CreateAssignmentClient({ clientId }: CreateAssignmentCli
         setMessage(`Successfully created ${createdAssignments.length} assignment(s)!`)
       }
 
-      // Send emails if enabled
+      // Send emails server-side if enabled (fire-and-forget — server handles delivery)
       if (sendEmail && createdAssignments.length > 0) {
-        // Group assignments by user
-        const assignmentsByUser = new Map<string, Array<{ assessmentTitle: string; url?: string | null }>>()
-        
-        for (const assignment of createdAssignments) {
-          const user = assignmentUsers.find(au => au.user_id === assignment.user_id)
-          if (!user) continue
-
-          const assessment = assessments.find(a => a.id === assignment.assessment_id)
-          if (!assessment) continue
-
-          if (!assignmentsByUser.has(user.user_id)) {
-            assignmentsByUser.set(user.user_id, [])
-          }
-          
-          assignmentsByUser.get(user.user_id)!.push({
-            assessmentTitle: assessment.title,
-            url: assignment.url,
-          })
-        }
-
-        // Send email to each user
-        const emailPromises: Array<Promise<Response>> = []
-        const emailUserMap: Array<{ userId: string; email: string; name: string }> = []
-        
-        for (const [userId, userAssignments] of assignmentsByUser.entries()) {
-          const user = assignmentUsers.find(au => au.user_id === userId)
-          if (!user) continue
-
-          emailUserMap.push({
-            userId,
-            email: user.user.email,
-            name: user.user.name,
-          })
-
-          // Get password for this user if available
-          const password = userPasswords.get(userId) || undefined
-
-          emailPromises.push(
-            fetch('/api/assignments/send-email', {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                to: user.user.email,
-                toName: user.user.name,
-                username: user.user.username,
-                subject: emailSubject || 'New assessments have been assigned to you',
-                body: emailBody || 'Hello {name}, you have been assigned {assessments}. Please complete by {expiration-date}. Dashboard: {dashboard-link}. © {year} Involved Talent.',
-                assignments: userAssignments,
-                expirationDate: expirationDate,
-                password: password,
-              }),
-            })
-          )
-        }
-
-        // Send all emails and track results
         try {
-          const emailResults = await Promise.allSettled(emailPromises)
-          const emailErrors: string[] = []
-          let emailSuccessCount = 0
-          let emailFailureCount = 0
-
-          // Process email results sequentially to properly await JSON parsing
-          for (let i = 0; i < emailResults.length; i++) {
-            const result = emailResults[i]
-            const userInfo = emailUserMap[i]
-            const userLabel = userInfo ? `${userInfo.name} (${userInfo.email})` : `Email ${i + 1}`
-            
-            if (result.status === 'fulfilled') {
-              const response = result.value
-              try {
-                if (response.ok) {
-                  const data = await response.json().catch(() => ({}))
-                  if (data.success !== false && !data.error) {
-                    emailSuccessCount++
-                    console.log(`✅ Email sent successfully to ${userLabel}`)
-                  } else {
-                    emailFailureCount++
-                    const errorMsg = data.error || data.message || 'Failed to send'
-                    emailErrors.push(`${userLabel}: ${errorMsg}`)
-                    console.error(`❌ Email failed for ${userLabel}:`, errorMsg)
-                  }
-                } else {
-                  emailFailureCount++
-                  const errorData = await response.json().catch(() => ({ error: `HTTP ${response.status}` }))
-                  const errorMsg = errorData.error || errorData.message || `HTTP ${response.status}`
-                  emailErrors.push(`${userLabel}: ${errorMsg}`)
-                  console.error(`❌ Email HTTP error for ${userLabel}:`, errorMsg)
-                }
-              } catch (parseError) {
-                emailFailureCount++
-                emailErrors.push(`${userLabel}: Failed to parse response`)
-                console.error(`❌ Email parse error for ${userLabel}:`, parseError)
-              }
-            } else {
-              emailFailureCount++
-              const errorMsg = result.reason?.message || 'Failed to send'
-              emailErrors.push(`${userLabel}: ${errorMsg}`)
-              console.error(`❌ Email promise rejected for ${userLabel}:`, errorMsg)
-            }
-          }
-
-          // Update message with email results
-          if (emailFailureCount > 0) {
-            const emailMsg = `⚠️ Emails: ${emailSuccessCount} sent, ${emailFailureCount} failed. ${emailErrors.slice(0, 3).join('; ')}${emailErrors.length > 3 ? '...' : ''}`
-            console.warn('Email sending issues:', emailMsg)
-            setMessage(prev => prev + (prev ? ' ' : '') + emailMsg)
-          } else if (emailSuccessCount > 0) {
-            console.log(`✅ Successfully sent ${emailSuccessCount} email notification(s)`)
-            setMessage(prev => prev + (prev ? ' ' : '') + `✅ ${emailSuccessCount} email notification(s) sent.`)
+          const batchRes = await fetch('/api/assignments/send-batch-email', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              assignment_ids: createdAssignments.map(a => a.id),
+              subject: emailSubject || undefined,
+              body: emailBody || undefined,
+              passwords: Object.fromEntries(userPasswords),
+            }),
+          })
+          const batchData = await batchRes.json()
+          if (batchRes.ok) {
+            setMessage(prev => prev + (prev ? ' ' : '') + `✅ ${batchData.queued} email notification(s) queued for delivery.`)
           } else {
-            console.warn('No emails were sent (no valid recipients or all failed)')
+            setMessage(prev => prev + (prev ? ' ' : '') + `⚠️ Email queuing failed: ${batchData.error}`)
           }
         } catch (emailError) {
-          console.error('Error processing email results:', emailError)
-          const emailErrorMsg = `⚠️ Warning: Email sending encountered an error: ${emailError instanceof Error ? emailError.message : 'Unknown error'}`
-          setMessage(prev => prev + (prev ? ' ' : '') + emailErrorMsg)
+          console.error('Error queuing emails:', emailError)
+          setMessage(prev => prev + (prev ? ' ' : '') + '⚠️ Email queuing failed. Check email dashboard for status.')
         }
       }
 

--- a/src/app/dashboard/clients/[id]/client-reports.tsx
+++ b/src/app/dashboard/clients/[id]/client-reports.tsx
@@ -16,10 +16,10 @@ interface Survey {
   survey_id: string
   assessment_id: string
   assessment_title: string
+  survey_name: string | null
   created_at: string
   total_assignments: number
   completed_assignments: number
-  first_assignment_date: string
 }
 
 export default function ClientReports({ clientId }: ClientReportsProps) {
@@ -68,122 +68,73 @@ export default function ClientReports({ clientId }: ClientReportsProps) {
     setIsLoading(true)
     setMessage('')
     try {
-      // Load all users for this client first
-      const { data: clientUsers, error: usersError } = await supabase
-        .from('profiles')
-        .select('id')
+      // Fetch surveys directly from the surveys table
+      let surveysQuery = supabase
+        .from('surveys')
+        .select(`
+          id,
+          name,
+          assessment_id,
+          created_at,
+          assessment:assessments!surveys_assessment_id_fkey(id, title)
+        `)
         .eq('client_id', clientId)
-
-      if (usersError) {
-        throw new Error(`Failed to load client users: ${usersError.message}`)
-      }
-
-      if (!clientUsers || clientUsers.length === 0) {
-        setSurveys([])
-        setIsLoading(false)
-        return
-      }
-
-      const userIds = clientUsers.map(u => u.id)
-
-      // Get all assignments for these users (not just completed - we want to see all surveys)
-      let assignmentsQuery = supabase
-        .from('assignments')
-        .select('id, assessment_id, survey_id, completed, created_at')
-        .in('user_id', userIds)
-        .not('survey_id', 'is', null) // Only show assignments with survey_id
+        .order('created_at', { ascending: false })
 
       // Apply assessment filter
       if (filterAssessmentId) {
-        assignmentsQuery = assignmentsQuery.eq('assessment_id', filterAssessmentId)
+        surveysQuery = surveysQuery.eq('assessment_id', filterAssessmentId)
       }
 
-      const { data: assignments, error: assignmentsError } = await assignmentsQuery
-        .order('created_at', { ascending: false })
+      const { data: surveysData, error: surveysError } = await surveysQuery
 
-      if (assignmentsError) {
-        throw new Error(`Failed to load assignments: ${assignmentsError.message || JSON.stringify(assignmentsError)}`)
+      if (surveysError) {
+        throw new Error(`Failed to load surveys: ${surveysError.message}`)
       }
 
-      if (!assignments || assignments.length === 0) {
+      if (!surveysData || surveysData.length === 0) {
         setSurveys([])
         setIsLoading(false)
         return
       }
 
-      // Group assignments by survey_id + assessment_id
-      const surveyMap = new Map<string, {
-        survey_id: string
-        assessment_id: string
-        assignments: Array<{ id: string; completed: boolean; created_at: string }>
-        first_created_at: string
-      }>()
+      // Get assignment counts and completion stats for each survey
+      const surveyIds = surveysData.map(s => s.id)
+      const { data: assignments, error: assignmentsError } = await supabase
+        .from('assignments')
+        .select('survey_id, completed')
+        .in('survey_id', surveyIds)
 
-      assignments.forEach((assignment) => {
-        if (!assignment.survey_id) {
-          return // Skip assignments without survey_id
-        }
-
-        const key = `${assignment.survey_id}_${assignment.assessment_id}`
-        
-        if (!surveyMap.has(key)) {
-          surveyMap.set(key, {
-            survey_id: assignment.survey_id,
-            assessment_id: assignment.assessment_id,
-            assignments: [],
-            first_created_at: assignment.created_at,
-          })
-        }
-
-        const survey = surveyMap.get(key)!
-        survey.assignments.push({
-          id: assignment.id,
-          completed: assignment.completed,
-          created_at: assignment.created_at,
-        })
-
-        // Track earliest created_at for this survey
-        if (new Date(assignment.created_at) < new Date(survey.first_created_at)) {
-          survey.first_created_at = assignment.created_at
-        }
-      })
-
-      // Get unique assessment IDs
-      const assessmentIds = [...new Set(Array.from(surveyMap.values()).map(s => s.assessment_id))]
-
-      // Load assessment metadata
-      const { data: assessmentsData, error: assessmentsError } = await supabase
-        .from('assessments')
-        .select('id, title')
-        .in('id', assessmentIds)
-
-      if (assessmentsError) {
-        throw new Error(`Failed to load assessments: ${assessmentsError.message}`)
+      if (assignmentsError) {
+        throw new Error(`Failed to load assignments: ${assignmentsError.message}`)
       }
 
-      const assessmentMap = new Map<string, string>()
-      assessmentsData?.forEach(a => {
-        assessmentMap.set(a.id, a.title)
-      })
+      // Build assignment stats map
+      const statsMap = new Map<string, { total: number; completed: number }>()
+      for (const a of (assignments || [])) {
+        if (!a.survey_id) continue
+        if (!statsMap.has(a.survey_id)) {
+          statsMap.set(a.survey_id, { total: 0, completed: 0 })
+        }
+        const s = statsMap.get(a.survey_id)!
+        s.total++
+        if (a.completed) s.completed++
+      }
 
-      // Build surveys array with completion stats
-      const surveysList: Survey[] = Array.from(surveyMap.values()).map(survey => {
-        const completedCount = survey.assignments.filter(a => a.completed).length
+      // Build surveys list
+      const surveysList: Survey[] = surveysData.map(s => {
+        const assessment = s.assessment as unknown as { id: string; title: string } | null
+        const stats = statsMap.get(s.id) || { total: 0, completed: 0 }
         return {
-          survey_id: survey.survey_id,
-          assessment_id: survey.assessment_id,
-          assessment_title: assessmentMap.get(survey.assessment_id) || 'Unknown Assessment',
-          created_at: survey.first_created_at,
-          total_assignments: survey.assignments.length,
-          completed_assignments: completedCount,
-          first_assignment_date: survey.first_created_at,
+          survey_id: s.id,
+          assessment_id: s.assessment_id,
+          assessment_title: assessment?.title || 'Unknown Assessment',
+          survey_name: s.name,
+          created_at: s.created_at,
+          total_assignments: stats.total,
+          completed_assignments: stats.completed,
         }
       })
-
-      // Sort by date (newest first)
-      surveysList.sort((a, b) => 
-        new Date(b.first_assignment_date).getTime() - new Date(a.first_assignment_date).getTime()
-      )
 
       setSurveys(surveysList)
 
@@ -196,7 +147,7 @@ export default function ClientReports({ clientId }: ClientReportsProps) {
       setAvailableAssessments(allAssessmentsData || [])
     } catch (error) {
       console.error('Error loading surveys:', error)
-      
+
       let errorMessage = 'Unknown error'
       if (error instanceof Error) {
         errorMessage = error.message
@@ -218,7 +169,7 @@ export default function ClientReports({ clientId }: ClientReportsProps) {
       } else {
         errorMessage = String(error)
       }
-      
+
       setMessage(`Failed to load surveys: ${errorMessage}`)
     } finally {
       setIsLoading(false)
@@ -230,10 +181,7 @@ export default function ClientReports({ clientId }: ClientReportsProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [clientId, filterAssessmentId])
 
-  const filteredSurveys = surveys.filter((survey) => {
-    if (filterAssessmentId && survey.assessment_id !== filterAssessmentId) return false
-    return true
-  })
+  const filteredSurveys = surveys
 
   if (isLoading) {
     return (
@@ -347,22 +295,26 @@ export default function ClientReports({ clientId }: ClientReportsProps) {
                       ? Math.round((survey.completed_assignments / survey.total_assignments) * 100)
                       : 0
                     const isComplete = survey.completed_assignments === survey.total_assignments && survey.total_assignments > 0
-                    const surveyDate = new Date(survey.first_assignment_date)
+                    const surveyDate = new Date(survey.created_at)
+                    const displayName = survey.survey_name || `${survey.assessment_title} - ${surveyDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
 
                     return (
                       <tr key={survey.survey_id} className="hover:bg-gray-50">
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="text-sm font-medium text-gray-900">
-                            {survey.assessment_title}
+                            {displayName}
                           </div>
+                          {survey.survey_name && (
+                            <div className="text-xs text-gray-500">{survey.assessment_title}</div>
+                          )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
                           <div className="text-sm text-gray-900">
-                            {surveyDate.toLocaleDateString('en-US', { 
-                              weekday: 'long', 
-                              year: 'numeric', 
-                              month: 'long', 
-                              day: 'numeric' 
+                            {surveyDate.toLocaleDateString('en-US', {
+                              weekday: 'long',
+                              year: 'numeric',
+                              month: 'long',
+                              day: 'numeric'
                             })}
                           </div>
                           <div className="text-sm text-gray-500 italic">
@@ -445,7 +397,7 @@ export default function ClientReports({ clientId }: ClientReportsProps) {
               </ul>
               <p className="text-sm font-medium text-gray-900 mb-1">Survey:</p>
               <p className="text-sm text-gray-600 mb-4">
-                {surveyToDelete.assessment_title} — {new Date(surveyToDelete.first_assignment_date).toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}
+                {surveyToDelete.survey_name || surveyToDelete.assessment_title} — {new Date(surveyToDelete.created_at).toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}
               </p>
               {deleteError && (
                 <p className="text-sm text-red-600 mb-4">{deleteError}</p>

--- a/src/app/dashboard/clients/[id]/client-surveys.tsx
+++ b/src/app/dashboard/clients/[id]/client-surveys.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { createClient } from '@/lib/supabase/client'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import Link from 'next/link'
+
+interface Survey {
+  id: string
+  name: string | null
+  assessment_id: string
+  created_at: string
+  updated_at: string
+  assessment_title: string
+  assignment_count: number
+  completed_count: number
+}
+
+export default function ClientSurveys({ clientId }: { clientId: string }) {
+  const [surveys, setSurveys] = useState<Survey[]>([])
+  const [loading, setLoading] = useState(true)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  const supabase = createClient()
+
+  const loadSurveys = useCallback(async () => {
+    setLoading(true)
+    const { data: surveyRows } = await supabase
+      .from('surveys')
+      .select('id, name, assessment_id, created_at, updated_at, assessment:assessments(title)')
+      .eq('client_id', clientId)
+      .order('created_at', { ascending: false })
+
+    if (!surveyRows) {
+      setSurveys([])
+      setLoading(false)
+      return
+    }
+
+    // Get assignment stats
+    const surveyIds = surveyRows.map(s => s.id)
+    const { data: assignments } = await supabase
+      .from('assignments')
+      .select('survey_id, completed')
+      .in('survey_id', surveyIds)
+
+    const statsMap = new Map<string, { total: number; completed: number }>()
+    for (const a of assignments || []) {
+      if (!a.survey_id) continue
+      const stats = statsMap.get(a.survey_id) || { total: 0, completed: 0 }
+      stats.total++
+      if (a.completed) stats.completed++
+      statsMap.set(a.survey_id, stats)
+    }
+
+    setSurveys(surveyRows.map(s => ({
+      id: s.id,
+      name: s.name,
+      assessment_id: s.assessment_id,
+      created_at: s.created_at,
+      updated_at: s.updated_at,
+      assessment_title: ((s.assessment as unknown) as { title: string } | null)?.title || 'Unknown',
+      assignment_count: statsMap.get(s.id)?.total || 0,
+      completed_count: statsMap.get(s.id)?.completed || 0,
+    })))
+    setLoading(false)
+  }, [clientId, supabase])
+
+  useEffect(() => { loadSurveys() }, [loadSurveys])
+
+  const handleSave = async (surveyId: string) => {
+    await supabase
+      .from('surveys')
+      .update({ name: editName || null })
+      .eq('id', surveyId)
+    setEditingId(null)
+    loadSurveys()
+  }
+
+  const handleDelete = async (surveyId: string) => {
+    if (!confirm('Delete this survey and all its assignments? This cannot be undone.')) return
+    // Delete assignments first (cascade should handle it, but explicit is safer)
+    await supabase.from('assignments').delete().eq('survey_id', surveyId)
+    await supabase.from('surveys').delete().eq('id', surveyId)
+    loadSurveys()
+  }
+
+  if (loading) {
+    return <div className="text-center py-8 text-gray-500">Loading surveys...</div>
+  }
+
+  if (surveys.length === 0) {
+    return (
+      <Card>
+        <CardContent className="text-center py-8 text-gray-500">
+          No surveys found for this client. Create assignments to start a survey.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <h2 className="text-lg font-semibold text-gray-900">Surveys ({surveys.length})</h2>
+      </div>
+
+      {surveys.map(survey => {
+        const isEditing = editingId === survey.id
+        const displayName = survey.name || `${survey.assessment_title} — ${new Date(survey.created_at).toLocaleDateString()}`
+        const completionPct = survey.assignment_count > 0
+          ? Math.round((survey.completed_count / survey.assignment_count) * 100)
+          : 0
+
+        return (
+          <Card key={survey.id} className="hover:shadow-md transition-shadow">
+            <CardHeader className="pb-2">
+              <div className="flex justify-between items-start">
+                <div className="flex-1">
+                  {isEditing ? (
+                    <div className="flex gap-2 items-center">
+                      <input
+                        type="text"
+                        value={editName}
+                        onChange={e => setEditName(e.target.value)}
+                        placeholder={`${survey.assessment_title} — ${new Date(survey.created_at).toLocaleDateString()}`}
+                        className="border rounded px-2 py-1 text-sm flex-1"
+                        autoFocus
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') handleSave(survey.id)
+                          if (e.key === 'Escape') setEditingId(null)
+                        }}
+                      />
+                      <Button size="sm" onClick={() => handleSave(survey.id)}>Save</Button>
+                      <Button size="sm" variant="outline" onClick={() => setEditingId(null)}>Cancel</Button>
+                    </div>
+                  ) : (
+                    <CardTitle className="text-base">
+                      <Link
+                        href={`/dashboard/clients/${clientId}/surveys/${survey.id}`}
+                        className="hover:text-indigo-600 transition-colors"
+                      >
+                        {displayName}
+                      </Link>
+                    </CardTitle>
+                  )}
+                  {survey.name && !isEditing && (
+                    <p className="text-sm text-gray-500 mt-0.5">{survey.assessment_title}</p>
+                  )}
+                </div>
+                {!isEditing && (
+                  <div className="flex gap-1 ml-4">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setEditingId(survey.id)
+                        setEditName(survey.name || '')
+                      }}
+                    >
+                      Rename
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                      onClick={() => handleDelete(survey.id)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="flex gap-6 text-sm text-gray-600">
+                <div>
+                  <span className="font-medium">{survey.assignment_count}</span> assignments
+                </div>
+                <div>
+                  <span className="font-medium">{survey.completed_count}</span> completed
+                </div>
+                <div>
+                  <span className="font-medium">{completionPct}%</span> completion
+                </div>
+                <div className="text-gray-400">
+                  Created {new Date(survey.created_at).toLocaleDateString()}
+                </div>
+              </div>
+              {survey.assignment_count > 0 && (
+                <div className="mt-2 w-full bg-gray-200 rounded-full h-1.5">
+                  <div
+                    className="bg-indigo-600 h-1.5 rounded-full transition-all"
+                    style={{ width: `${completionPct}%` }}
+                  />
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/dashboard/clients/[id]/client-tabs.tsx
+++ b/src/app/dashboard/clients/[id]/client-tabs.tsx
@@ -8,6 +8,7 @@ import ClientUsers from './client-users'
 import ClientGroups from './client-groups'
 import ClientAssignments from './client-assignments'
 import ClientReports from './client-reports'
+import ClientSurveys from './client-surveys'
 import ClientSurveySimulator from './client-survey-simulator'
 
 interface ClientTabsProps {
@@ -42,6 +43,7 @@ export default function ClientTabs({ clientId, activeTab: initialTab, client, is
     { id: 'details', label: 'Details' },
     { id: 'users', label: 'Users' },
     { id: 'groups', label: 'Groups' },
+    { id: 'surveys', label: 'Surveys' },
     { id: 'assignments', label: 'Assignments' },
     { id: 'reports', label: 'Reports' },
     ...(isSuperAdmin ? [{ id: 'simulate', label: 'Simulate Survey' }] : []),
@@ -216,6 +218,7 @@ export default function ClientTabs({ clientId, activeTab: initialTab, client, is
 
         {activeTab === 'users' && <ClientUsers clientId={clientId} />}
         {activeTab === 'groups' && <ClientGroups clientId={clientId} />}
+        {activeTab === 'surveys' && <ClientSurveys clientId={clientId} />}
         {activeTab === 'assignments' && <ClientAssignments clientId={clientId} />}
         {activeTab === 'reports' && <ClientReports clientId={clientId} />}
         {activeTab === 'simulate' && isSuperAdmin && <ClientSurveySimulator clientId={clientId} />}

--- a/src/app/dashboard/clients/[id]/surveys/[surveyId]/page.tsx
+++ b/src/app/dashboard/clients/[id]/surveys/[surveyId]/page.tsx
@@ -15,24 +15,24 @@ export default async function SurveyDetailPage({ params }: SurveyDetailPageProps
   const { id: clientId, surveyId } = await params
   const adminClient = createAdminClient()
 
-  // Validate survey exists and get first assignment to determine assessment
-  const { data: firstAssignment, error: assignmentError } = await adminClient
-    .from('assignments')
+  // Fetch survey metadata from the surveys table
+  const { data: surveyRow, error: surveyError } = await adminClient
+    .from('surveys')
     .select(`
       id,
+      name,
       assessment_id,
       created_at,
-      assessment:assessments!assignments_assessment_id_fkey(
+      assessment:assessments!surveys_assessment_id_fkey(
         id,
         title,
         is_360
       )
     `)
-    .eq('survey_id', surveyId)
-    .limit(1)
+    .eq('id', surveyId)
     .single()
 
-  if (assignmentError || !firstAssignment) {
+  if (surveyError || !surveyRow) {
     redirect(`/dashboard/clients/${clientId}?tab=reports`)
   }
 
@@ -105,7 +105,7 @@ export default async function SurveyDetailPage({ params }: SurveyDetailPageProps
   })
 
   // Type assertion for assessment
-  const assessment = (firstAssignment.assessment as unknown) as {
+  const assessment = (surveyRow.assessment as unknown) as {
     id: string
     title: string
     is_360: boolean
@@ -113,6 +113,13 @@ export default async function SurveyDetailPage({ params }: SurveyDetailPageProps
 
   if (!assessment) {
     redirect(`/dashboard/clients/${clientId}?tab=reports`)
+  }
+
+  // Build survey metadata for the client component
+  const surveyMeta = {
+    id: surveyRow.id,
+    name: surveyRow.name as string | null,
+    created_at: surveyRow.created_at,
   }
 
   // Get subjects and scores on the server (these functions use admin client)
@@ -137,6 +144,7 @@ export default async function SurveyDetailPage({ params }: SurveyDetailPageProps
     <SurveyDetailClient
       clientId={clientId}
       surveyId={surveyId}
+      surveyMeta={surveyMeta}
       assessment={assessment}
       assignments={validAssignments}
       initialSubjects={subjects}

--- a/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
+++ b/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import Link from 'next/link'
-import { Calendar, ChevronDown, ChevronRight, ExternalLink, Pencil, Trash2 } from 'lucide-react'
+import { Calendar, ChevronDown, ChevronRight, Download, ExternalLink, Pencil, Trash2 } from 'lucide-react'
 import { PdfActionButtons } from '@/components/reports/pdf-action-buttons'
 import SurveySnapshots from '@/components/surveys/survey-snapshots'
 import { Subject } from '@/lib/reports/get-survey-subjects'
@@ -405,6 +405,17 @@ export default function SurveyDetailClient({
           >
             <Trash2 className="h-4 w-4 mr-2" />
             Delete survey
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              window.open(`/api/clients/${clientId}/surveys/${surveyId}/export-csv`, '_blank')
+            }}
+            aria-label="Export raw data CSV"
+          >
+            <Download className="h-4 w-4 mr-2" />
+            Export Raw Data
           </Button>
         </div>
       </div>

--- a/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
+++ b/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
@@ -105,6 +105,7 @@ export default function SurveyDetailClient({
     tomorrow.setDate(tomorrow.getDate() + 1)
     return tomorrow.toISOString().split('T')[0]
   })
+  const [firstReminderTime, setFirstReminderTime] = useState('09:00')
   const [isUpdatingReminders, setIsUpdatingReminders] = useState(false)
 
   const incompleteCount = assignments.filter(a => !a.completed).length
@@ -118,7 +119,7 @@ export default function SurveyDetailClient({
         body: JSON.stringify({
           reminder: true,
           reminder_frequency: reminderFrequency,
-          first_reminder_date: `${firstReminderDate}T09:00:00`,
+          first_reminder_date: `${firstReminderDate}T${firstReminderTime}:00`,
         }),
       })
       const data = await res.json()
@@ -492,12 +493,20 @@ export default function SurveyDetailClient({
               <div className="flex flex-wrap gap-4 items-end">
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">First Reminder</label>
-                  <input
-                    type="date"
-                    value={firstReminderDate}
-                    onChange={e => setFirstReminderDate(e.target.value)}
-                    className="border rounded px-2 py-1 text-sm"
-                  />
+                  <div className="flex gap-2">
+                    <input
+                      type="date"
+                      value={firstReminderDate}
+                      onChange={e => setFirstReminderDate(e.target.value)}
+                      className="border rounded px-2 py-1 text-sm"
+                    />
+                    <input
+                      type="time"
+                      value={firstReminderTime}
+                      onChange={e => setFirstReminderTime(e.target.value)}
+                      className="border rounded px-2 py-1 text-sm"
+                    />
+                  </div>
                 </div>
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">Frequency</label>
@@ -521,7 +530,7 @@ export default function SurveyDetailClient({
                 </Button>
               </div>
               <p className="text-xs text-amber-700 mt-2">
-                Reminders are sent daily at 9 AM UTC to users who haven&apos;t completed their assessment.
+                First reminder sends at the specified date/time. Subsequent reminders repeat at the selected frequency until completed.
               </p>
             </CardContent>
           </Card>

--- a/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
+++ b/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
@@ -97,6 +97,63 @@ export default function SurveyDetailClient({
   const [deleteSelectedDialogOpen, setDeleteSelectedDialogOpen] = useState(false)
   const [isDeletingSelected, setIsDeletingSelected] = useState(false)
 
+  // Reminder state
+  const [showReminderSettings, setShowReminderSettings] = useState(false)
+  const [reminderFrequency, setReminderFrequency] = useState('+3 days')
+  const [firstReminderDate, setFirstReminderDate] = useState(() => {
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    return tomorrow.toISOString().split('T')[0]
+  })
+  const [isUpdatingReminders, setIsUpdatingReminders] = useState(false)
+
+  const incompleteCount = assignments.filter(a => !a.completed).length
+
+  const handleEnableReminders = async () => {
+    setIsUpdatingReminders(true)
+    try {
+      const res = await fetch(`/api/clients/${clientId}/surveys/${surveyId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          reminder: true,
+          reminder_frequency: reminderFrequency,
+          first_reminder_date: `${firstReminderDate}T09:00:00`,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) {
+        setMessage(data.error || 'Failed to enable reminders')
+      } else {
+        setMessage(`Reminders enabled for ${incompleteCount} incomplete assignment(s)`)
+        setShowReminderSettings(false)
+      }
+    } catch {
+      setMessage('Failed to enable reminders')
+    } finally {
+      setIsUpdatingReminders(false)
+    }
+  }
+
+  const handleDisableReminders = async () => {
+    setIsUpdatingReminders(true)
+    try {
+      const res = await fetch(`/api/clients/${clientId}/surveys/${surveyId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ reminder: false }),
+      })
+      if (res.ok) {
+        setMessage('Reminders disabled')
+        setShowReminderSettings(false)
+      }
+    } catch {
+      setMessage('Failed to disable reminders')
+    } finally {
+      setIsUpdatingReminders(false)
+    }
+  }
+
   const handleDeleteSurvey = async () => {
     setIsDeleting(true)
     setDeleteError(null)
@@ -417,7 +474,58 @@ export default function SurveyDetailClient({
             <Download className="h-4 w-4 mr-2" />
             Export Raw Data
           </Button>
+          {incompleteCount > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowReminderSettings(!showReminderSettings)}
+            >
+              <Calendar className="h-4 w-4 mr-2" />
+              Reminders ({incompleteCount} pending)
+            </Button>
+          )}
         </div>
+
+        {showReminderSettings && (
+          <Card className="border-amber-300 bg-amber-50">
+            <CardContent className="pt-4">
+              <div className="flex flex-wrap gap-4 items-end">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">First Reminder</label>
+                  <input
+                    type="date"
+                    value={firstReminderDate}
+                    onChange={e => setFirstReminderDate(e.target.value)}
+                    className="border rounded px-2 py-1 text-sm"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Frequency</label>
+                  <select
+                    value={reminderFrequency}
+                    onChange={e => setReminderFrequency(e.target.value)}
+                    className="border rounded px-2 py-1 text-sm"
+                  >
+                    <option value="+1 day">Every day</option>
+                    <option value="+2 days">Every 2 days</option>
+                    <option value="+3 days">Every 3 days</option>
+                    <option value="+1 week">Every week</option>
+                    <option value="+2 weeks">Every 2 weeks</option>
+                  </select>
+                </div>
+                <Button size="sm" onClick={handleEnableReminders} disabled={isUpdatingReminders}>
+                  {isUpdatingReminders ? 'Updating...' : `Enable for ${incompleteCount} incomplete`}
+                </Button>
+                <Button size="sm" variant="outline" onClick={handleDisableReminders} disabled={isUpdatingReminders}>
+                  Disable All
+                </Button>
+              </div>
+              <p className="text-xs text-amber-700 mt-2">
+                Reminders are sent daily at 9 AM UTC to users who haven&apos;t completed their assessment.
+              </p>
+            </CardContent>
+          </Card>
+        )}
       </div>
 
       {/* Fixed message (toaster) */}

--- a/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
+++ b/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
@@ -32,6 +32,11 @@ export type SurveyAssignment = {
 interface SurveyDetailClientProps {
   clientId: string
   surveyId: string
+  surveyMeta?: {
+    id: string
+    name: string | null
+    created_at: string
+  }
   assessment: {
     id: string
     title: string
@@ -45,6 +50,7 @@ interface SurveyDetailClientProps {
 export default function SurveyDetailClient({
   clientId,
   surveyId,
+  surveyMeta,
   assessment,
   assignments: initialAssignments,
   initialSubjects = [],
@@ -205,9 +211,12 @@ export default function SurveyDetailClient({
   const completedCount = assignments.filter(a => a.completed).length
   const totalCount = assignments.length
   const completionPercent = totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0
-  const surveyDate = assignments.length > 0
-    ? new Date(assignments[0].created_at)
-    : new Date()
+  const surveyDate = surveyMeta?.created_at
+    ? new Date(surveyMeta.created_at)
+    : assignments.length > 0
+      ? new Date(assignments[0].created_at)
+      : new Date()
+  const surveyDisplayName = surveyMeta?.name || `${assessment.title} Survey`
   const currentDeadline = assignments.find(a => a.expires)?.expires
     ? new Date(assignments.find(a => a.expires)!.expires!).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })
     : null
@@ -365,7 +374,10 @@ export default function SurveyDetailClient({
               ← Back to Surveys
             </Button>
           </Link>
-          <h2 className="text-xl font-bold text-gray-900">{assessment.title} Survey</h2>
+          <h2 className="text-xl font-bold text-gray-900">{surveyDisplayName}</h2>
+          {surveyMeta?.name && (
+            <p className="text-sm text-gray-500">{assessment.title}</p>
+          )}
           <p className="text-gray-600">
             Survey launched on {surveyDate.toLocaleDateString('en-US', { 
               weekday: 'long', 
@@ -903,7 +915,7 @@ export default function SurveyDetailClient({
           </ul>
           <p className="text-sm font-medium text-gray-900 mb-1">Survey:</p>
           <p className="text-sm text-gray-600 mb-4">
-            {assessment.title} — {surveyDate.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}
+            {surveyDisplayName} — {surveyDate.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' })}
           </p>
           {deleteError && (
             <p className="text-sm text-red-600 mb-4">{deleteError}</p>

--- a/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
+++ b/src/app/dashboard/clients/[id]/surveys/[surveyId]/survey-detail-client.tsx
@@ -119,7 +119,7 @@ export default function SurveyDetailClient({
         body: JSON.stringify({
           reminder: true,
           reminder_frequency: reminderFrequency,
-          first_reminder_date: `${firstReminderDate}T${firstReminderTime}:00`,
+          first_reminder_date: new Date(`${firstReminderDate}T${firstReminderTime}`).toISOString(),
         }),
       })
       const data = await res.json()

--- a/src/components/reports/360-report-view-fullscreen.tsx
+++ b/src/components/reports/360-report-view-fullscreen.tsx
@@ -413,9 +413,7 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                {dimension.industry_benchmark != null
-                                  ? (dimension.industry_benchmark ?? 0).toFixed(2)
-                                  : '0.00'}
+                                {(dimension.geonorm ?? 0).toFixed(2)}
                               </div>
                               <div
                                 className="norm-label"
@@ -428,10 +426,8 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                GEONORM for<br />
-                                <span style={{ fontWeight: 600 }}>
-                                  {dimension.industry_benchmark !== null ? 'Industry' : 'NO INDUSTRY SET'}
-                                </span>
+                                GEONORM<br />
+                                <span style={{ fontWeight: 600 }}>Avg Score For This Group</span>
                               </div>
                             </div>
                           </div>
@@ -482,7 +478,9 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                {(dimension.geonorm ?? 0).toFixed(2)}
+                                {dimension.industry_benchmark != null
+                                  ? (dimension.industry_benchmark ?? 0).toFixed(2)
+                                  : '0.00'}
                               </div>
                               <div
                                 className="norm-label"
@@ -495,8 +493,10 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                Avg Score<br />
-                                <span style={{ fontWeight: 600 }}>For This Group</span>
+                                Benchmark<br />
+                                <span style={{ fontWeight: 600 }}>
+                                  {dimension.industry_benchmark !== null ? (reportData.industry_name || 'Industry') : 'NO INDUSTRY SET'}
+                                </span>
                               </div>
                             </div>
                           </div>
@@ -552,7 +552,7 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                             >
                               GEONORM for<br />
                               <span style={{ fontWeight: 600 }}>
-                                {dimension.industry_benchmark !== null ? 'Industry' : 'NO INDUSTRY SET'}
+                                {dimension.industry_benchmark !== null ? (reportData.industry_name || 'Industry') : 'NO INDUSTRY SET'}
                               </span>
                             </div>
                           </div>

--- a/src/components/reports/360-report-view-fullscreen.tsx
+++ b/src/components/reports/360-report-view-fullscreen.tsx
@@ -413,7 +413,9 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                {(dimension.geonorm ?? 0).toFixed(2)}
+                                {dimension.industry_benchmark != null
+                                  ? (dimension.industry_benchmark ?? 0).toFixed(2)
+                                  : '0.00'}
                               </div>
                               <div
                                 className="norm-label"
@@ -426,8 +428,10 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                GEONORM<br />
-                                <span style={{ fontWeight: 600 }}>Avg Score For This Group</span>
+                                AVG SCORE<br />
+                                <span style={{ fontWeight: 600 }}>
+                                  {dimension.industry_benchmark !== null ? (reportData.industry_name || 'Industry') : 'NO INDUSTRY SET'}
+                                </span>
                               </div>
                             </div>
                           </div>
@@ -478,9 +482,7 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                {dimension.industry_benchmark != null
-                                  ? (dimension.industry_benchmark ?? 0).toFixed(2)
-                                  : '0.00'}
+                                {(dimension.geonorm ?? 0).toFixed(2)}
                               </div>
                               <div
                                 className="norm-label"
@@ -493,10 +495,8 @@ export default function Report360ViewFullscreen({ reportData }: Report360ViewFul
                                   flexShrink: 0,
                                 }}
                               >
-                                Benchmark<br />
-                                <span style={{ fontWeight: 600 }}>
-                                  {dimension.industry_benchmark !== null ? (reportData.industry_name || 'Industry') : 'NO INDUSTRY SET'}
-                                </span>
+                                GEONORM<br />
+                                <span style={{ fontWeight: 600 }}>For This Group</span>
                               </div>
                             </div>
                           </div>

--- a/src/lib/reports/calculate-geonorms.ts
+++ b/src/lib/reports/calculate-geonorms.ts
@@ -25,7 +25,8 @@ export interface GEOnorm {
 export async function calculateGEOnorms(
   groupId: string,
   assessmentId: string,
-  dimensionIds: string[]
+  dimensionIds: string[],
+  surveyId?: string | null
 ): Promise<Map<string, GEOnorm>> {
   const adminClient = createAdminClient()
 
@@ -45,13 +46,17 @@ export async function calculateGEOnorms(
 
   const memberIds = groupMembers.map((gm) => gm.profile_id)
 
-  // Get all completed assignments for group members and this assessment
-  const { data: assignments } = await adminClient
+  // Get all completed assignments for group members, scoped to this survey
+  let assignmentsQuery = adminClient
     .from('assignments')
     .select('id, user_id')
     .in('user_id', memberIds)
     .eq('assessment_id', assessmentId)
     .eq('completed', true)
+  if (surveyId) {
+    assignmentsQuery = assignmentsQuery.eq('survey_id', surveyId)
+  }
+  const { data: assignments } = await assignmentsQuery
 
   if (!assignments || assignments.length === 0) {
     return new Map()

--- a/src/lib/reports/export-survey-csv.ts
+++ b/src/lib/reports/export-survey-csv.ts
@@ -1,0 +1,167 @@
+/**
+ * Raw survey data CSV export
+ *
+ * Exports individual user responses for a survey — not aggregated scores.
+ * Each row is one user's answer to one question.
+ * This is for internal data verification only, never shown to clients.
+ */
+
+import { createAdminClient } from '@/lib/supabase/admin'
+
+function escapeCsv(field: string | number | null | undefined): string {
+  if (field === null || field === undefined) return ''
+  const str = String(field)
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`
+  }
+  return str
+}
+
+export async function exportSurveyRawCSV(surveyId: string): Promise<string> {
+  const adminClient = createAdminClient()
+
+  // Get survey metadata
+  const { data: survey } = await adminClient
+    .from('surveys')
+    .select('id, assessment_id, client_id, name, created_at, assessment:assessments(title)')
+    .eq('id', surveyId)
+    .single()
+
+  if (!survey) throw new Error('Survey not found')
+
+  // Get all assignments for this survey with user and target info
+  const { data: assignments } = await adminClient
+    .from('assignments')
+    .select(`
+      id, user_id, target_id, completed, started_at, completed_at,
+      user:profiles!assignments_user_id_fkey(id, name, email),
+      target:profiles!assignments_target_id_fkey(id, name, email)
+    `)
+    .eq('survey_id', surveyId)
+
+  if (!assignments || assignments.length === 0) {
+    return 'No assignments found for this survey'
+  }
+
+  // Get all fields (questions) for the assessment
+  const { data: fields } = await adminClient
+    .from('fields')
+    .select('id, type, content, dimension_id, order')
+    .eq('assessment_id', survey.assessment_id)
+    .in('type', ['multiple_choice', 'text_input'])
+    .order('order')
+
+  // Get dimensions for name lookup
+  const { data: dimensions } = await adminClient
+    .from('dimensions')
+    .select('id, name, code')
+    .eq('assessment_id', survey.assessment_id)
+
+  const dimMap = new Map((dimensions || []).map(d => [d.id, d]))
+
+  // Get all answers for these assignments
+  const assignmentIds = assignments.map(a => a.id)
+  let allAnswers: Array<{ assignment_id: string; field_id: string; value: string; time?: number }> = []
+  for (let i = 0; i < assignmentIds.length; i += 20) {
+    const batch = assignmentIds.slice(i, i + 20)
+    const { data } = await adminClient
+      .from('answers')
+      .select('assignment_id, field_id, value, time')
+      .in('assignment_id', batch)
+    if (data) allAnswers = allAnswers.concat(data)
+  }
+
+  // Build answer lookup: assignment_id:field_id -> answer
+  const answerMap = new Map<string, { value: string; time?: number }>()
+  for (const a of allAnswers) {
+    answerMap.set(`${a.assignment_id}:${a.field_id}`, { value: a.value, time: a.time })
+  }
+
+  // Get anchors for multiple choice fields to resolve numeric values to labels
+  const { data: mcFields } = await adminClient
+    .from('fields')
+    .select('id, anchors')
+    .eq('assessment_id', survey.assessment_id)
+    .eq('type', 'multiple_choice')
+
+  const anchorMap = new Map<string, Array<{ name: string; value: number }>>()
+  for (const f of mcFields || []) {
+    if (f.anchors && Array.isArray(f.anchors)) {
+      anchorMap.set(f.id, f.anchors as Array<{ name: string; value: number }>)
+    }
+  }
+
+  // Build CSV
+  const lines: string[] = []
+
+  // Header
+  const assessmentTitle = ((survey.assessment as unknown) as { title: string })?.title || 'Unknown'
+  lines.push(`Survey Raw Data Export`)
+  lines.push(`Assessment: ${escapeCsv(assessmentTitle)}`)
+  lines.push(`Survey ID: ${escapeCsv(survey.id)}`)
+  lines.push(`Exported: ${new Date().toISOString()}`)
+  lines.push('')
+
+  // Column headers
+  lines.push([
+    'User Name',
+    'User Email',
+    'Target Name',
+    'Target Email',
+    'Assignment Status',
+    'Dimension',
+    'Dimension Code',
+    'Question Type',
+    'Question',
+    'Raw Value',
+    'Label',
+    'Response Time (s)',
+  ].map(escapeCsv).join(','))
+
+  // Data rows: one per user per question
+  for (const assignment of assignments) {
+    const user = (assignment.user as unknown) as { name: string; email: string } | null
+    const target = (assignment.target as unknown) as { name: string; email: string } | null
+    const status = assignment.completed ? 'Completed' : (assignment.started_at ? 'In Progress' : 'Not Started')
+
+    for (const field of fields || []) {
+      const dim = field.dimension_id ? dimMap.get(field.dimension_id) : null
+      const answer = answerMap.get(`${assignment.id}:${field.id}`)
+
+      // Strip HTML from question content for CSV
+      const questionText = (field.content || '').replace(/<[^>]+>/g, '').substring(0, 200)
+
+      let rawValue = answer?.value ?? ''
+      let label = ''
+
+      if (field.type === 'multiple_choice' && answer) {
+        const anchors = anchorMap.get(field.id)
+        const idx = parseInt(answer.value)
+        if (anchors && !isNaN(idx) && idx >= 0 && idx < anchors.length) {
+          label = anchors[idx].name
+        }
+        rawValue = answer.value
+      } else if (field.type === 'text_input' && answer) {
+        rawValue = answer.value
+        label = answer.value
+      }
+
+      lines.push([
+        user?.name || '',
+        user?.email || '',
+        target?.name || '',
+        target?.email || '',
+        status,
+        dim?.name || '',
+        dim?.code || '',
+        field.type,
+        questionText,
+        rawValue,
+        label,
+        answer?.time?.toString() || '',
+      ].map(escapeCsv).join(','))
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/src/lib/reports/generate-360-report.ts
+++ b/src/lib/reports/generate-360-report.ts
@@ -181,7 +181,7 @@ export async function generate360Report(
   // Get all dimensions for this assessment (needed for both full and partial report)
   const { data: dimensions } = await adminClient
     .from('dimensions')
-    .select('id, name, code, parent_id, sort_order')
+    .select('id, name, code, parent_id, sort_order, definition')
     .eq('assessment_id', assignment.assessment_id)
     .is('parent_id', null) // Get top-level dimensions only
     .order('sort_order', { ascending: true })
@@ -301,21 +301,13 @@ export async function generate360Report(
   // Calculate GEOnorms
   const geonorms = await calculateGEOnorms(group.id, assignment.assessment_id, dimensionIds, assignment.survey_id)
 
-  // Get description fields (rich_text) for each dimension
-  const { data: descriptionFields } = await adminClient
-    .from('fields')
-    .select('dimension_id, content')
-    .eq('assessment_id', assignment.assessment_id)
-    .eq('type', 'rich_text')
-    .in('dimension_id', dimensionIds)
-  
+  // Get definitions from dimensions (single source of truth)
+  // Falls back to rich_text fields for backward compatibility
   const descriptionByDimension = new Map<string, string>()
-  descriptionFields?.forEach((field) => {
-    if (field.dimension_id && field.content) {
-      // If multiple description fields exist for a dimension, use the first one
-      if (!descriptionByDimension.has(field.dimension_id)) {
-        descriptionByDimension.set(field.dimension_id, field.content)
-      }
+  dimensions.forEach((dim) => {
+    const d = dim as { id: string; definition?: string | null }
+    if (d.definition) {
+      descriptionByDimension.set(d.id, d.definition)
     }
   })
 

--- a/src/lib/reports/generate-360-report.ts
+++ b/src/lib/reports/generate-360-report.ts
@@ -74,6 +74,7 @@ export async function generate360Report(
       assessment_id,
       target_id,
       group_id,
+      survey_id,
       assessment:assessments!assignments_assessment_id_fkey(
         id,
         title
@@ -123,7 +124,7 @@ export async function generate360Report(
     groupFromDb = groupsByTarget[0]
   }
 
-  // Get all assignments for this target (and this group when known)
+  // Get all assignments for this target, scoped to the same survey
   let allTargetAssignmentsQuery = adminClient
     .from('assignments')
     .select(`
@@ -140,6 +141,10 @@ export async function generate360Report(
     .eq('target_id', assignment.target_id)
     .eq('assessment_id', assignment.assessment_id)
     .eq('completed', true)
+  // Filter by survey_id to prevent cross-survey score contamination
+  if (assignment.survey_id) {
+    allTargetAssignmentsQuery = allTargetAssignmentsQuery.eq('survey_id', assignment.survey_id)
+  }
   if (groupFromDb?.id) {
     allTargetAssignmentsQuery = allTargetAssignmentsQuery.eq('group_id', groupFromDb.id)
   }
@@ -147,7 +152,7 @@ export async function generate360Report(
 
   // When group filter yielded zero, retry without group so partial completion still produces a report
   if (groupFromDb?.id && (!allTargetAssignments || allTargetAssignments.length === 0)) {
-    const { data: fallbackAssignments } = await adminClient
+    let fallbackQuery = adminClient
       .from('assignments')
       .select(`
         id,
@@ -163,6 +168,10 @@ export async function generate360Report(
       .eq('target_id', assignment.target_id)
       .eq('assessment_id', assignment.assessment_id)
       .eq('completed', true)
+    if (assignment.survey_id) {
+      fallbackQuery = fallbackQuery.eq('survey_id', assignment.survey_id)
+    }
+    const { data: fallbackAssignments } = await fallbackQuery
     allTargetAssignments = fallbackAssignments || []
   }
 
@@ -274,19 +283,23 @@ export async function generate360Report(
     .in('assignment_id', assignmentIds)
     .in('dimension_id', dimensionIds)
 
-  // Get industry benchmarks
+  // Get industry benchmarks with industry name
   const { data: benchmarks } = await adminClient
     .from('benchmarks')
-    .select('dimension_id, value')
+    .select('dimension_id, value, industry_id, industry:industries!benchmarks_industry_id_fkey(name)')
     .in('dimension_id', dimensionIds)
 
   const benchmarkMap = new Map<string, number>()
+  let industryName: string | null = null
   benchmarks?.forEach((b) => {
     benchmarkMap.set(b.dimension_id, b.value)
+    if (!industryName && b.industry) {
+      industryName = (b.industry as { name: string }).name
+    }
   })
 
   // Calculate GEOnorms
-  const geonorms = await calculateGEOnorms(group.id, assignment.assessment_id, dimensionIds)
+  const geonorms = await calculateGEOnorms(group.id, assignment.assessment_id, dimensionIds, assignment.survey_id)
 
   // Get description fields (rich_text) for each dimension
   const { data: descriptionFields } = await adminClient
@@ -519,6 +532,7 @@ export async function generate360Report(
     group_id: group.id,
     group_name: group.name,
     overall_score: overallScore,
+    industry_name: industryName,
     dimensions: dimensionReports,
     generated_at: new Date().toISOString(),
     ...(isPartial && {

--- a/src/lib/reports/generate-360-report.ts
+++ b/src/lib/reports/generate-360-report.ts
@@ -294,7 +294,7 @@ export async function generate360Report(
   benchmarks?.forEach((b) => {
     benchmarkMap.set(b.dimension_id, b.value)
     if (!industryName && b.industry) {
-      industryName = (b.industry as { name: string }).name
+      industryName = ((b.industry as unknown) as { name: string })?.name || null
     }
   })
 

--- a/src/lib/reports/generate-leader-blocker-report.ts
+++ b/src/lib/reports/generate-leader-blocker-report.ts
@@ -38,6 +38,7 @@ export async function generateLeaderBlockerReport(
       target_id,
       assessment_id,
       created_at,
+      survey_id,
       user:profiles!assignments_user_id_fkey(
         id,
         name,
@@ -146,19 +147,21 @@ export async function generateLeaderBlockerReport(
     geonorms = await calculateGEOnorms(group.id, assignment.assessment_id, allDimensionIds)
   }
 
-  // Get all assignments in the same batch for group score calculation
-  // For Leaders/Blockers: Group scores are calculated across all targets in the group
-  // Same assessment_id and created_at (same assessment batch)
-  // The target's own score comes from all assignments that rated this target (handled separately)
-  const batchCreatedAt = assignment.created_at
-
-  const { data: assignmentBatch } = await adminClient
+  // Get all assignments in the same survey for group score calculation
+  // For Leaders/Blockers: Group scores are calculated across all targets in the survey
+  let batchQuery = adminClient
     .from('assignments')
     .select('id, user_id, target_id, created_at')
     .eq('assessment_id', assignment.assessment_id)
     .eq('completed', true)
-    .eq('created_at', batchCreatedAt)
-    .limit(1000) // Reasonable limit
+    .limit(1000)
+  if (assignment.survey_id) {
+    batchQuery = batchQuery.eq('survey_id', assignment.survey_id)
+  } else {
+    // Legacy fallback: match by created_at timestamp
+    batchQuery = batchQuery.eq('created_at', assignment.created_at)
+  }
+  const { data: assignmentBatch } = await batchQuery
 
   const batchAssignments = assignmentBatch || []
   

--- a/src/lib/reports/types.ts
+++ b/src/lib/reports/types.ts
@@ -57,6 +57,7 @@ export interface Report360Data {
   group_id: string
   group_name: string
   overall_score: number
+  industry_name?: string | null
   dimensions: DimensionReport360[]
   generated_at: string
   /** True when no or partial responses; report shows placeholders. */

--- a/supabase/functions/send-reminders/index.ts
+++ b/supabase/functions/send-reminders/index.ts
@@ -85,15 +85,12 @@ serve(async (req) => {
     // Initialize Supabase admin client
     const supabase = createClient(supabaseUrl, supabaseServiceKey)
 
-    // Get current time and tomorrow (to catch reminders due today)
+    // Find reminders that are due (next_reminder <= now)
     const now = new Date()
-    const tomorrow = new Date(now)
-    tomorrow.setDate(tomorrow.getDate() + 1)
-    tomorrow.setHours(0, 0, 0, 0)
 
-    console.log(`🔍 Checking for reminders due between ${now.toISOString()} and ${tomorrow.toISOString()}`)
+    console.log(`🔍 Checking for reminders due before ${now.toISOString()}`)
 
-    // Query assignments due for reminders
+    // Query assignments where reminder time has passed
     const { data: assignments, error: queryError } = await supabase
       .from('assignments')
       .select(`
@@ -108,8 +105,7 @@ serve(async (req) => {
       .eq('reminder', true)
       .eq('completed', false)
       .not('next_reminder', 'is', null)
-      .gte('next_reminder', now.toISOString())
-      .lt('next_reminder', tomorrow.toISOString())
+      .lte('next_reminder', now.toISOString())
 
     if (queryError) {
       console.error('❌ Error querying assignments:', queryError)

--- a/supabase/migrations/20260401000000_create_surveys_table.sql
+++ b/supabase/migrations/20260401000000_create_surveys_table.sql
@@ -1,0 +1,79 @@
+-- Create surveys table: first-class entity for survey rounds
+-- Previously, surveys were just a UUID grouping on assignments.survey_id
+
+CREATE TABLE IF NOT EXISTS surveys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  client_id UUID REFERENCES clients(id) ON DELETE CASCADE NOT NULL,
+  assessment_id UUID REFERENCES assessments(id) ON DELETE CASCADE NOT NULL,
+  name TEXT,
+  created_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+  updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Index for client-scoped queries
+CREATE INDEX idx_surveys_client_id ON surveys(client_id);
+CREATE INDEX idx_surveys_assessment_id ON surveys(assessment_id);
+
+-- Updated_at trigger
+CREATE TRIGGER update_surveys_updated_at
+  BEFORE UPDATE ON surveys
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Enable RLS
+ALTER TABLE surveys ENABLE ROW LEVEL SECURITY;
+
+-- RLS policies: same pattern as other client-scoped tables
+CREATE POLICY "Service role has full access to surveys"
+  ON surveys FOR ALL
+  USING (auth.role() = 'service_role');
+
+CREATE POLICY "Users can view surveys for their client"
+  ON surveys FOR SELECT
+  USING (
+    client_id IN (
+      SELECT client_id FROM profiles WHERE auth_user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Admins can manage surveys for their client"
+  ON surveys FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM profiles
+      WHERE auth_user_id = auth.uid()
+      AND (role = 'admin' OR access_level = 'super_admin')
+      AND (client_id = surveys.client_id OR access_level = 'super_admin')
+    )
+  );
+
+-- Backfill: create survey rows from existing assignment data
+-- Each distinct survey_id on assignments becomes a row in surveys
+INSERT INTO surveys (id, client_id, assessment_id, created_at, updated_at)
+SELECT DISTINCT ON (a.survey_id)
+  a.survey_id,
+  COALESCE(g.client_id, p.client_id),
+  a.assessment_id,
+  MIN(a.created_at) OVER (PARTITION BY a.survey_id),
+  now()
+FROM assignments a
+LEFT JOIN groups g ON g.id = a.group_id
+LEFT JOIN profiles p ON p.id = a.user_id
+WHERE a.survey_id IS NOT NULL
+ORDER BY a.survey_id, a.created_at ASC
+ON CONFLICT (id) DO NOTHING;
+
+-- Add FK constraint on assignments.survey_id
+ALTER TABLE assignments
+  ADD CONSTRAINT assignments_survey_id_fkey
+  FOREIGN KEY (survey_id) REFERENCES surveys(id) ON DELETE SET NULL;
+
+-- Fix survey_snapshots: change survey_id from TEXT to UUID and add FK
+-- First drop the old column and recreate as UUID
+ALTER TABLE survey_snapshots
+  ALTER COLUMN survey_id TYPE UUID USING survey_id::uuid;
+
+ALTER TABLE survey_snapshots
+  ADD CONSTRAINT survey_snapshots_survey_id_fkey
+  FOREIGN KEY (survey_id) REFERENCES surveys(id) ON DELETE CASCADE;

--- a/supabase/migrations/20260402000000_add_definition_to_dimensions.sql
+++ b/supabase/migrations/20260402000000_add_definition_to_dimensions.sql
@@ -1,0 +1,23 @@
+-- Add definition column to dimensions table (single source of truth)
+-- Previously, definitions were stored as rich_text fields in the fields table
+
+ALTER TABLE dimensions ADD COLUMN IF NOT EXISTS definition TEXT;
+
+-- Add definition_display setting to assessments
+-- Controls how dimension definitions render on the assessment-taking flow
+-- 'none' = don't show (default — preserves existing behavior)
+-- 'above' = show definition above each dimension's questions
+-- 'below' = show definition below each dimension's questions
+-- 'page' = show all definitions on a dedicated page before questions
+ALTER TABLE assessments ADD COLUMN IF NOT EXISTS definition_display TEXT DEFAULT 'none';
+
+-- Backfill: copy definitions from rich_text fields into dimensions.definition
+-- Only update where dimensions.definition is currently NULL
+UPDATE dimensions d
+SET definition = f.content
+FROM fields f
+WHERE f.dimension_id = d.id
+  AND f.type = 'rich_text'
+  AND f.content IS NOT NULL
+  AND f.content != ''
+  AND d.definition IS NULL;

--- a/supabase/migrations/20260402010000_update_reminder_cron_hourly.sql
+++ b/supabase/migrations/20260402010000_update_reminder_cron_hourly.sql
@@ -1,0 +1,24 @@
+-- Change reminder cron from daily (9 AM UTC) to hourly
+-- This allows reminders to fire within an hour of their scheduled time
+-- instead of waiting up to 24 hours for the next daily run
+
+SELECT cron.unschedule('send-assignment-reminders');
+
+SELECT cron.schedule(
+  'send-assignment-reminders',
+  '0 * * * *', -- Top of every hour
+  $$
+  SELECT
+    net.http_post(
+      url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'reminder_project_url') || '/functions/v1/send-reminders',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'Authorization', 'Bearer ' || (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'reminder_service_role_key')
+      ),
+      body := jsonb_build_object(
+        'triggered_at', now(),
+        'source', 'pg_cron'
+      )
+    ) AS request_id;
+  $$
+);


### PR DESCRIPTION
## Summary

### Surveys Table
- First-class `surveys` table with backfill from existing data + FK constraints
- New Surveys tab on client page (rename, delete, progress bars)
- All UI components updated to query surveys table directly
- Assignment creation pre-creates survey row server-side
- Survey CRUD API endpoint (POST /api/surveys)

### Report Bug Fixes
- **Survey collision**: filter by survey_id in 360 report, leader-blocker report, and geonorm calculation
- **Industry name**: resolve from benchmarks table, replace hardcoded "Industry" string
- **Card swap**: AVG Score (benchmark) on left, Geonorm on right per Craig
- **PDF auth**: simplified service role key comparison for Edge Function calls
- **PDF race condition**: auto-generate report data before PDF export if missing

### Dimension Definitions
- New `definition` column on dimensions table (single source of truth)
- `definition_display` setting on assessments (none/above/below/page)
- Backfill from existing rich_text fields
- Report generator reads from dimensions.definition
- Editor reads/writes dimensions.definition directly
- Rich_text definition fields filtered from editor view

### Email Architecture
- **Server-side batch email**: new POST /api/assignments/send-batch-email
- Assignment creation UI sends one call to batch endpoint instead of N browser fetches
- Server sends emails in background — user can navigate away safely
- Timezone fix: local time properly converted to UTC for reminder dates

### Reminders
- Survey-level reminder management (enable/disable from survey detail page)
- Date + time picker for first reminder
- Frequency selector (daily through biweekly)
- Hourly cron instead of daily
- Fixed reminder query: finds due reminders (past), not future ones

### CSV Export
- Raw survey data export (individual user responses per question)
- Export button on survey detail page

## Test plan
- [x] Local: surveys table, collision fix, card swap, industry name
- [x] Staging: migration + code deployed and verified
- [x] Production: migration applied, reports regenerated
- [ ] PDF generation working end-to-end
- [ ] Reminder emails send at correct local time
- [ ] Batch email endpoint handles 100+ assignments without timeout
- [ ] CSV export downloads with correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)