### PR TITLE
Fix dim-insert-on-retry: route name collisions through existing rows

### DIFF
--- a/src/app/dashboard/assessments/[id]/edit/edit-client.tsx
+++ b/src/app/dashboard/assessments/[id]/edit/edit-client.tsx
@@ -485,11 +485,32 @@ export default function EditAssessmentClient({ id }: EditAssessmentClientProps) 
         }
         const sortedNew = [...newToInsert].sort((a, b) => getDimensionLevel(a.id) - getDimensionLevel(b.id))
 
+        // Idempotency: if a prior save partially committed a dim row (insert succeeded
+        // but a later step in this handler threw), the form still holds the temp id.
+        // On retry, route those temp-id rows to UPDATE against the existing DB row
+        // matched by (assessment_id, name) so we don't trip the UNIQUE constraint.
+        const existingByName = new Map<string, { id: string }>()
+        for (const d of existingDimensions || []) existingByName.set(d.name, { id: d.id })
+
         for (const dim of sortedNew) {
           let parentId: string | null = null
           if (dim.parent_id) {
             parentId = tempIdToDbIdMap.get(dim.parent_id) || (uuidRegex.test(dim.parent_id) ? dim.parent_id : null)
           }
+          const sortOrder = originalOrder.indexOf(dim.id) + 1
+
+          const collision = existingByName.get(dim.name)
+          if (collision) {
+            const { error } = await supabase
+              .from('dimensions')
+              .update({ name: dim.name, code: dim.code, parent_id: parentId, sort_order: sortOrder })
+              .eq('id', collision.id)
+            if (error) throw new Error(`Failed to reconcile dimension: ${error.message}`)
+            tempIdToDbIdMap.set(dim.id, collision.id)
+            existingDimIds.add(collision.id)
+            continue
+          }
+
           const { data: inserted, error } = await supabase
             .from('dimensions')
             .insert({
@@ -497,12 +518,15 @@ export default function EditAssessmentClient({ id }: EditAssessmentClientProps) 
               name: dim.name,
               code: dim.code,
               parent_id: parentId,
-              sort_order: originalOrder.indexOf(dim.id) + 1,
+              sort_order: sortOrder,
             })
             .select('id')
             .single()
           if (error) throw new Error(`Failed to insert dimension: ${error.message}`)
-          if (inserted) tempIdToDbIdMap.set(dim.id, inserted.id)
+          if (inserted) {
+            tempIdToDbIdMap.set(dim.id, inserted.id)
+            existingByName.set(dim.name, { id: inserted.id })
+          }
         }
 
         // Delete dimensions that were removed from the form


### PR DESCRIPTION
## Summary

Fixes a hard error Craig hit while building the new Frontier 360 on
production: `Failed to insert dimension: duplicate key value violates
unique constraint dimensions_assessment_id_name_key`.

Root cause: when a prior save partially committed (dim INSERT succeeded
but a later step in the handler threw), the form state still held the
temp id for the row that did make it to the DB. On retry, the temp id
failed the `uuidRegex.test() && existingDimIds.has()` check, so the
code went straight to INSERT against the same `(assessment_id, name)`
that's already there. Backing out and re-entering masked the bug (the
fresh load populated form rows with real UUIDs, routing them to UPDATE).

This is a stale-form-state bug, not a constraint problem.

## Fix

Surgical change in `edit-client.tsx`: before INSERT-ing a new dim, look
up existing dimensions by `(assessment_id, name)`. If one exists, treat
the form row as an update against that existing real id and seed the
temp-id-to-real-id map so child rows (parent_id references) resolve
correctly. Idempotent on partial-save retries.

No schema change.

## Out of scope (separate followups)

- Same shape of bug almost certainly affects fields and questions, but
  those don't have a name uniqueness constraint, so they fail differently
  (silent duplicates rather than a hard error). Worth filing on its own.

## Test plan

- [ ] Open an existing 360 in production
- [ ] Add a new dimension, save → succeeds, normal path
- [ ] Cause a save to partially fail (e.g. add a malformed field after a
      good dim), retry the save → no more duplicate-key error; the
      partially-committed dim is reconciled to its existing row

🤖 Generated with [Claude Code](https://claude.com/claude-code)